### PR TITLE
create Common.Http services

### DIFF
--- a/Roo.Azure.Configuration.Common.Http/AzureAdAuthentication/AzureAdClientAssertion.cs
+++ b/Roo.Azure.Configuration.Common.Http/AzureAdAuthentication/AzureAdClientAssertion.cs
@@ -1,0 +1,224 @@
+﻿using Azure.Core;
+using Azure.Identity;
+using Azure.Security.KeyVault.Certificates;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.IdentityModel.Tokens;
+using Newtonsoft.Json;
+using Roo.Azure.Configuration.Common.Http.Models;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Roo.Azure.Configuration.Common.Http.AzureAdAuthentication
+{
+    /// <summary>
+    /// Authentication using Azure Active Directory.
+    /// </summary>
+    public interface IAzureAdClientAssertion
+    {
+        /// <summary>
+        /// Get Azure Active Directory token using certificate authentication. Certificate must have a RSA private key.
+        /// </summary>
+        /// <param name="tenantId">Azure Ad Tenant Id.</param>
+        /// <param name="clientId">Azure Ad Client Id.</param>
+        /// <param name="scope">Scope of application, not the Azure AD subscription.</param>
+        /// <param name="certificate">Certificate to authenticate against in Azure Active Directory. Must have a RSA private key.</param>
+        /// <param name="tokenName">Token name stored in cache.</param>
+        /// <returns></returns>
+        public Task<string?> GetTokenAsync(string tenantId, string clientId, string scope, X509Certificate2 certificate, string? tokenName = null);
+
+        /// <summary>
+        /// Get Azure Active Directory token using client secret authentication.
+        /// </summary>
+        /// <param name="tenantId"></param>
+        /// <param name="clientId"></param>
+        /// <param name="scope"></param>
+        /// <param name="clientSecret"></param>
+        /// <param name="tokenName"></param>
+        /// <returns></returns>
+        public Task<string?> GetTokenAsync(string tenantId, string clientId, string scope, string clientSecret, string? tokenName = null);
+
+        /// <summary>
+        /// Get a certificate stored in Azure Key Vault.
+        /// </summary>
+        /// <param name="certName">Name of certificate stored in Key Vault.</param>
+        /// <param name="keyVaultUri">Uri of Key Vault.</param>
+        /// <param name="token">Credential with authorization to the Key Vault, thie credential must have Certificate Get permission.</param>
+        /// <returns></returns>
+        public Task<X509Certificate2?> GetCertificateFromKeyVault(string certName, string keyVaultUri, TokenCredential? token = null);
+
+        /// <summary>
+        /// Convert a string to a certificate with a password.
+        /// </summary>
+        /// <param name="certString"></param>
+        /// <param name="password"></param>
+        /// <returns></returns>
+        public X509Certificate2? GenerateCertificateFromString(string certString, string password);
+    }
+
+    /// <summary>
+    /// Authentication using Azure Active Directory.
+    /// </summary>
+    public class AzureAdClientAssertion : IAzureAdClientAssertion
+    {
+        private readonly IMemoryCache _cache;
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <param name="cache"></param>
+        public AzureAdClientAssertion(IMemoryCache cache)
+        {
+            _cache = cache;
+        }
+
+        private static string GenerateClientAssertion(string clientId, string tenantId, X509Certificate2 certificate)
+        {
+            //Create signing credentials
+            var signingCredentials = new X509SigningCredentials(certificate, SecurityAlgorithms.RsaSha256);
+
+            //Define token descriptor
+            var tokenDescriptor = new SecurityTokenDescriptor
+            {
+                Audience = "https://login.microsoftonline.com/" + tenantId + "/v2.0",
+                Issuer = clientId,
+                Subject = new System.Security.Claims.ClaimsIdentity([new Claim("sub", clientId)]),
+                Expires = DateTime.UtcNow.AddMinutes(10),
+                SigningCredentials = signingCredentials
+            };
+
+            //Create token handler
+            var tokenHandler = new JwtSecurityTokenHandler();
+
+            //Create token
+            var securityToken = tokenHandler.CreateToken(tokenDescriptor);
+
+            //Write token as a string
+            var clientAssertion = tokenHandler.WriteToken(securityToken);
+            return clientAssertion;
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <param name="tenantId"></param>
+        /// <param name="clientId"></param>
+        /// <param name="scope"></param>
+        /// <param name="certificate"></param>
+        /// <param name="tokenName"></param>
+        /// <returns></returns>
+        public async Task<string?> GetTokenAsync(string tenantId, string clientId, string scope, X509Certificate2 certificate, string? tokenName = null)
+        {
+            //Check if token is already in cache
+            var token = !string.IsNullOrEmpty(tokenName) ? _cache.Get<string>(tokenName) : null;
+
+            if (!string.IsNullOrEmpty(token))
+            {
+                return token;
+            }
+
+            var clientAssertion = GenerateClientAssertion(clientId, tenantId, certificate);
+
+            var requestContent = new FormUrlEncodedContent([
+                new KeyValuePair<string, string>("client_id", clientId),
+                new KeyValuePair<string, string>("client_assertion", clientAssertion),
+                new KeyValuePair<string, string>("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"),
+                new KeyValuePair<string, string>("grant_type", "client_credentials"),
+                new KeyValuePair<string, string>("scope", scope),
+            ]);
+
+            return await RequestToken(tenantId, requestContent, tokenName);
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <param name="tenantId"></param>
+        /// <param name="clientId"></param>
+        /// <param name="scope"></param>
+        /// <param name="clientSecret"></param>
+        /// <param name="tokenName"></param>
+        /// <returns></returns>
+        public async Task<string?> GetTokenAsync(string tenantId, string clientId, string scope, string clientSecret, string? tokenName = null)
+        {
+            //Check if token is already in cache
+            var token = !string.IsNullOrEmpty(tokenName) ? _cache.Get<string>(tokenName) : null;
+
+            if (!string.IsNullOrEmpty(token))
+            {
+                return token;
+            }
+
+            var requestContent = new FormUrlEncodedContent([
+                new KeyValuePair<string, string>("client_id", clientId),
+                new KeyValuePair<string, string>("client_secret", clientSecret),
+                new KeyValuePair<string, string>("grant_type", "client_credentials"),
+                new KeyValuePair<string, string>("scope", scope),
+            ]);
+
+            return await RequestToken(tenantId, requestContent, tokenName);
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <param name="certName"></param>
+        /// <param name="keyVaultUri"></param>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        public async Task<X509Certificate2?> GetCertificateFromKeyVault(string certName, string keyVaultUri, TokenCredential? token = null)
+        {
+            var client = new CertificateClient(new Uri(keyVaultUri), token ?? new DefaultAzureCredential());
+            var download = await client.DownloadCertificateAsync(certName);
+            if (download != null)
+            {
+                return download.Value;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <param name="certString"></param>
+        /// <returns></returns>
+        public X509Certificate2? GenerateCertificateFromString(string certString, string password)
+        {
+            var certBytes = Convert.FromBase64String(certString);
+            var cert = new X509Certificate2(certBytes, password);
+            return cert;
+        }
+
+        private async Task<string?> RequestToken(string tenantId, FormUrlEncodedContent requestContent, string? tokenName = null)
+        {
+            using (HttpClient httpClient = new())
+            {
+                //Create request URL
+                var endpoint = $"https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/token";
+
+                //Send request
+                var response = await httpClient.PostAsync(endpoint, requestContent);
+
+                //Ensure response is successful
+                response.EnsureSuccessStatusCode();
+
+                //Read response content
+                var responseContent = await response.Content.ReadAsStringAsync();
+
+                //Extract token from response
+                var tokenObject = JsonConvert.DeserializeObject<AzureAdTokenResponse>(responseContent);
+                var token = tokenObject?.AccessToken;
+
+                if (string.IsNullOrEmpty(token))
+                {
+                    return null;
+                }
+                if (!string.IsNullOrEmpty(tokenName))
+                {
+                    _cache.Set(tokenName, token, DateTimeOffset.UtcNow.AddMinutes(58));
+                }
+                return token;
+            }
+        }
+    }
+}

--- a/Roo.Azure.Configuration.Common.Http/AzureAdAuthentication/AzureAdClientAssertionHelper.cs
+++ b/Roo.Azure.Configuration.Common.Http/AzureAdAuthentication/AzureAdClientAssertionHelper.cs
@@ -1,0 +1,83 @@
+﻿using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Text.Json;
+
+namespace Roo.Azure.Configuration.Common.Http.AzureAdAuthentication
+{
+    public class AzureAdClientAssertionHelper
+    {
+        private const uint JwtToAadLifetimeInSeconds = 600;
+        private readonly static char Base64PadCharacter = '=';
+        private readonly static char Base64Character62 = '+';
+        private readonly static char Base64Character63 = '/';
+        private readonly static char Base64UrlCharacter62 = '-';
+        private readonly static char Base64UrlCharacter63 = '-';
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="certificate"></param>
+        /// <param name="tenantId"></param>
+        /// <param name="clientId"></param>
+        /// <returns></returns>
+        public static string? GetSignedClientAssertion(X509Certificate2 certificate, string tenantId, string clientId)
+        {
+            //Get RSA with private key for signing
+            var rsa = certificate.GetRSAPrivateKey();
+            if (rsa == null)
+            {
+                return null;
+            }
+
+            //alg is the signing algorithm, SHA-256
+            //x5t is the certificate thumbprint, encoded in base64
+            var header = new Dictionary<string, string>()
+            {
+                { "alg", "RS256" },
+                { "typ", "JWT" },
+                { "x5t", Base64UrlEncode(certificate.GetCertHash()) }
+            };
+
+            var claims = GetClaims(tenantId, clientId);
+            var headerBytes = JsonSerializer.SerializeToUtf8Bytes(header);
+            var claimsBytes = JsonSerializer.SerializeToUtf8Bytes(claims);
+            var token = Base64UrlEncode(headerBytes) + "." + Base64UrlEncode(claimsBytes);
+            var signature = Base64UrlEncode(rsa.SignData(Encoding.UTF8.GetBytes(token), HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1));
+            var signedClientAssertion = string.Concat(token, ".", signature);
+            return signedClientAssertion;
+        }
+
+        /// <summary>
+        /// Convert byte array to an encoded string.
+        /// </summary>
+        /// <param name="arg"></param>
+        /// <returns></returns>
+        public static string Base64UrlEncode(byte[] arg)
+        {
+            var s = Convert.ToBase64String(arg);
+            s = s.Split(Base64PadCharacter)[0]; //Remove any trailing padding
+            s = s.Replace(Base64Character62, Base64UrlCharacter62); //62nd char of encoding
+            s = s.Replace(Base64Character63, Base64UrlCharacter63); //63nd char of encoding
+            return s;
+        }
+
+        private static Dictionary<string, object> GetClaims(string tenantId, string clientId)
+        {
+            var adLogin = $"https://login.microsoftonline.com/{tenantId}/v2.0";
+            var validFrom = DateTimeOffset.UtcNow;
+            var validUntil = validFrom.AddSeconds(JwtToAadLifetimeInSeconds);
+
+            return new Dictionary<string, object>()
+            {
+                { "aud", adLogin },
+                { "exp", validUntil.ToUnixTimeSeconds() },
+                { "iss", clientId },
+                { "jti", Guid.NewGuid().ToString() },
+                { "nbf", validFrom.ToUnixTimeSeconds() },
+                { "sub", clientId },
+                { "iat", validFrom.ToUnixTimeSeconds() }
+            };
+        }
+    }
+}

--- a/Roo.Azure.Configuration.Common.Http/HttpContentExtensions.cs
+++ b/Roo.Azure.Configuration.Common.Http/HttpContentExtensions.cs
@@ -1,0 +1,29 @@
+﻿namespace Roo.Azure.Configuration.Common.Http
+{
+    /// <summary>
+    /// Extension methods for HttpContent.
+    /// </summary>
+    public static class HttpContentExtensions
+    {
+        /// <summary>
+        /// Read as string safely so a <see cref="NullReferenceException"/> isn't thrown if content is null.
+        /// </summary>
+        /// <param name="content"></param>
+        /// <param name="defaultValue"></param>
+        /// <returns></returns>
+        public static async Task<string?> SafeReadAsStringAsync(this HttpContent content, string? defaultValue = null)
+        {
+            return (content != null ? await content.ReadAsStringAsync().ConfigureAwait(false) : null) ?? defaultValue;
+        }
+
+        /// <summary>
+        /// Read as stream safely so a <see cref="NullReferenceException"/> isn't thrown if content is null.
+        /// </summary>
+        /// <param name="content"></param>
+        /// <returns></returns>
+        public static async Task<Stream?> SafeReadAsStreamAsync(this HttpContent content)
+        {
+            return content != null ? await content.ReadAsStreamAsync().ConfigureAwait(false) : null;
+        }
+    }
+}

--- a/Roo.Azure.Configuration.Common.Http/IRooHttpClient.cs
+++ b/Roo.Azure.Configuration.Common.Http/IRooHttpClient.cs
@@ -1,0 +1,268 @@
+﻿using Microsoft.AspNetCore.Http;
+using Roo.Azure.Configuration.Common.Http.Models;
+using Roo.Azure.Configuration.Common.Models;
+
+namespace Roo.Azure.Configuration.Common.Http
+{
+    /// <summary>
+    /// HttpClient wrapper to standardize HTTP calls, add the headers, authorize tokens, and deserialize responses.<br/>
+    /// Common input parameters:<br/>
+    /// relativeUrl: Relative URL with query parameters already configured, unless queryParameters is used.<br/>
+    /// httpClientName: Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.<br/>
+    /// queryParameters: Dictionary of query parameter names and values that will be configured and appended to URL.<br/>
+    /// </summary>
+    public interface IRooHttpClient
+    {
+        /// <summary>
+        /// Current HttpContext, required. Use DefaultHttpContext if used in a non-context application
+        /// </summary>
+        public HttpContext? HttpContext { get; set; }
+
+        /// <summary>
+        /// Used to overwrite existing channel-id header
+        /// </summary>
+        public string? ChannelId { get; set; }
+
+        /// <summary>
+        /// Used to overwrite existing session-id header
+        /// </summary>
+        public string? SessionId { get; set; }
+
+        /// <summary>
+        /// Used to overwrite existing transaction-id header
+        /// </summary>
+        public string? TransactionId { get; set; }
+
+        /// <summary>
+        /// Use to overwrite/set user-info header
+        /// </summary>
+        public UserInfo? UserInfo { get; set; }
+
+        /// <summary>
+        /// <inheritdoc cref="Models.AuthenticationInfo"/>
+        /// </summary>
+        public AuthenticationInfo? AuthenticationInfo { get; set; }
+
+        /// <summary>
+        /// <inheritdoc cref="Models.SerializationSettings"/>
+        /// </summary>
+        public SerializationSettings? SerializationSettings { get; set; }
+
+        /// <summary>
+        /// GetAsync without object deserialization.
+        /// </summary>
+        /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
+        /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
+        /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <returns></returns>
+        public Task<HttpResponseMessage> GetAsync(string relativeUrl, string httpClientName, List<(string Parameter, string Value)>? queryParameters = null);
+
+        /// <summary>
+        /// GetAsync without object deserialization and an object query parameter.
+        /// </summary>
+        /// <typeparam name="TResult"></typeparam>
+        /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
+        /// <param name="httpClientName">Relative URL with query parameters already configured.</param>
+        /// <param name="queryStringObject">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <returns></returns>
+        public Task<HttpResponseMessage> GetAsync(string relativeUrl, string httpClientName, object queryStringObject);
+
+        /// <summary>
+        /// GetAsync with object deserialization.
+        /// </summary>
+        /// <typeparam name="TResult">Object that response should be deserialized into.</typeparam>
+        /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
+        /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
+        /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <returns></returns>
+        public Task<TResult> GetAsync<TResult>(string relativeUrl, string httpClientName, List<(string Parameter, string Value)>? queryParameters = null);
+
+        /// <summary>
+        /// GetAsync with object deserialization and an object query parameter.
+        /// </summary>
+        /// <typeparam name="TResult">Object that response should be deserialized into.</typeparam>
+        /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
+        /// <param name="httpClientName">Relative URL with query parameters already configured.</param>
+        /// <param name="queryStringObject">Object that will be converted to a query string.</param>
+        /// <returns></returns>
+        public Task<TResult> GetAsync<TResult>(string relativeUrl, string httpClientName, object queryStringObject);
+
+        /// <summary>
+        /// <inheritdoc cref="GetAsync(string, string, List{ValueTuple{string, string}}?)"/>
+        /// </summary>
+        /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
+        /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
+        /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <returns></returns>
+        public Task<HttpResponseMessage> GetAsync(string relativeUrl, Enum httpClientName, List<(string Parameter, string Value)>? queryParameters = null);
+
+        /// <summary>
+        /// <inheritdoc cref="GetAsync(string, string, object)"/>
+        /// </summary>
+        /// <typeparam name="TResult"></typeparam>
+        /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
+        /// <param name="httpClientName">Relative URL with query parameters already configured.</param>
+        /// <param name="queryStringObject">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <returns></returns>
+        public Task<HttpResponseMessage> GetAsync(string relativeUrl, Enum httpClientName, object queryStringObject);
+
+        /// <summary>
+        /// <inheritdoc cref="GetAsync{TResult}(string, string, List{ValueTuple{string, string}}?)"/>
+        /// </summary>
+        /// <typeparam name="TResult">Object that response should be deserialized into.</typeparam>
+        /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
+        /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
+        /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <returns></returns>
+        public Task<TResult> GetAsync<TResult>(string relativeUrl, Enum httpClientName, List<(string Parameter, string Value)>? queryParameters = null);
+
+        /// <summary>
+        /// <inheritdoc cref="GetAsync{TResult}(string, string, object)"/>
+        /// </summary>
+        /// <typeparam name="TResult">Object that response should be deserialized into.</typeparam>
+        /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
+        /// <param name="httpClientName">Relative URL with query parameters already configured.</param>
+        /// <param name="queryStringObject">Object that will be converted to a query string.</param>
+        /// <returns></returns>
+        public Task<TResult> GetAsync<TResult>(string relativeUrl, Enum httpClientName, object queryStringObject);
+
+        /// <summary>
+        /// PostAsync without object deserialization.
+        /// </summary>
+        /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
+        /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
+        /// <param name="data">Object to be sent with POST. Takes precedence over HttpContent, MultipartFormDataContent, and MultipartContent if more than one is used.</param>
+        /// <param name="content">HttpContent to be sent with POST. Will be ignored if object is used but takes precedence over MultipartFormDataContent and MultipartContent if more than one is used.</param>
+        /// <param name="formData">MultipartFormDataContent to be sent with POST. Will be ignored if object or HttpContent is used but takes precedence over MultipartContent if more than one is used.</param>
+        /// <param name="multipartContent">MultipartContent to be sent with POST. Will be ignored if object, HttpContent, or MultipartFormDataContent if more than one is used.</param>
+        /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <returns></returns>
+        public Task<HttpResponseMessage> PostAsync(string relativeUrl, string httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null);
+
+        /// <summary>
+        /// PostAsync with object deserialization.
+        /// </summary>
+        /// <typeparam name="TResult">Object that response should be deserialized into.</typeparam>
+        /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
+        /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
+        /// <param name="data">Object to be sent with POST. Takes precedence over HttpContent, MultipartFormDataContent, and MultipartContent if more than one is used.</param>
+        /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <returns></returns>
+        public Task<TResult> PostAsync<TResult>(string relativeUrl, string httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null);
+
+        /// <summary>
+        /// <inheritdoc cref="PostAsync(string, string, object?, List{ValueTuple{string, string}}?)"/>
+        /// </summary>
+        /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
+        /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
+        /// <param name="data">Object to be sent with POST. Takes precedence over HttpContent, MultipartFormDataContent, and MultipartContent if more than one is used.</param>
+        /// <param name="content">HttpContent to be sent with POST. Will be ignored if object is used but takes precedence over MultipartFormDataContent and MultipartContent if more than one is used.</param>
+        /// <param name="formData">MultipartFormDataContent to be sent with POST. Will be ignored if object or HttpContent is used but takes precedence over MultipartContent if more than one is used.</param>
+        /// <param name="multipartContent">MultipartContent to be sent with POST. Will be ignored if object, HttpContent, or MultipartFormDataContent if more than one is used.</param>
+        /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <returns></returns>
+        public Task<HttpResponseMessage> PostAsync(string relativeUrl, Enum httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null);
+
+        /// <summary>
+        /// <inheritdoc cref="PostAsync{TResult}(string, string, object?, List{ValueTuple{string, string}}?)"/>
+        /// </summary>
+        /// <typeparam name="TResult">Object that response should be deserialized into.</typeparam>
+        /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
+        /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
+        /// <param name="data">Object to be sent with POST. Takes precedence over HttpContent, MultipartFormDataContent, and MultipartContent if more than one is used.</param>
+        /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <returns></returns>
+        public Task<TResult> PostAsync<TResult>(string relativeUrl, Enum httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null);
+
+        /// <summary>
+        /// PutAsync without object deserialization.
+        /// </summary>
+        /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
+        /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
+        /// <param name="data">Object to be sent with PUT. Takes precedence over HttpContent, MultipartFormDataContent, and MultipartContent if more than one is used.</param>
+        /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <returns></returns>
+        public Task<HttpResponseMessage> PutAsync(string relativeUrl, string httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null);
+
+        /// <summary>
+        /// PutAsync with object deserialization.
+        /// </summary>
+        /// <typeparam name="TResult">Object that response should be deserialized into.</typeparam>
+        /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
+        /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
+        /// <param name="data">Object to be sent with PUT. Takes precedence over HttpContent, MultipartFormDataContent, and MultipartContent if more than one is used.</param>
+        /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <returns></returns>
+        public Task<TResult> PutAsync<TResult>(string relativeUrl, string httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null);
+
+        /// <summary>
+        /// <inheritdoc cref="PutAsync(string, string, object?, List{ValueTuple{string, string}}?)"/>
+        /// </summary>
+        /// <param name="relativeUrl"><Relative URL with query parameters already configured, unless a query Dictionary is used.></param>
+        /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
+        /// <param name="data">Object to be sent with PUT. Takes precedence over HttpContent, MultipartFormDataContent, and MultipartContent if more than one is used.</param>
+        /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <returns></returns>
+        public Task<HttpResponseMessage> PutAsync(string relativeUrl, Enum httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null);
+
+        /// <summary>
+        /// <inheritdoc cref="PutAsync{TResult}(string, string, object?, List{ValueTuple{string, string}}?)"/>
+        /// </summary>
+        /// <typeparam name="TResult">Object that response should be deserialized into.</typeparam>
+        /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
+        /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
+        /// <param name="data">Object to be sent with PUT. Takes precedence over HttpContent, MultipartFormDataContent, and MultipartContent if more than one is used.</param>
+        /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <returns></returns>
+        public Task<TResult> PutAsync<TResult>(string relativeUrl, Enum httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null);
+
+        /// <summary>
+        /// DeleteAsync with object deserialization.
+        /// </summary>
+        /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
+        /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
+        /// <param name="data">Object to be sent with DELETE. Takes precedence over HttpContent, MultipartFormDataContent, and MultipartContent if more than one is used.</param>
+        /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <returns></returns>
+        public Task<HttpResponseMessage> DeleteAsync(string relativeUrl, string httpClientName, List<(string Parameter, string Value)>? queryParameters = null);
+
+        /// <summary>
+        /// DeleteAsync with object deserialization.
+        /// </summary>
+        /// <typeparam name="TResult">Object that response should be deserialized into.</typeparam>
+        /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
+        /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
+        /// <param name="data">Object to be sent with DELETE. Takes precedence over HttpContent, MultipartFormDataContent, and MultipartContent if more than one is used.</param>
+        /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <returns></returns>
+        public Task<TResult> DeleteAsync<TResult>(string relativeUrl, string httpClientName, List<(string Parameter, string Value)>? queryParameters = null);
+
+        /// <summary>
+        /// <inheritdoc cref="DeleteAsync(string, string, List{ValueTuple{string, string}}?)"/>>
+        /// </summary>
+        /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
+        /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
+        /// <param name="data">Object to be sent with DELETE. Takes precedence over HttpContent, MultipartFormDataContent, and MultipartContent if more than one is used.</param>
+        /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <returns></returns>
+        public Task<HttpResponseMessage> DeleteAsync(string relativeUrl, Enum httpClientName, List<(string Parameter, string Value)>? queryParameters = null);
+
+        /// <summary>
+        /// <inheritdoc cref="DeleteAsync{TResult}(string, string, List{ValueTuple{string, string}}?)"/>
+        /// </summary>
+        /// <typeparam name="TResult">Object that response should be deserialized into.</typeparam>
+        /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
+        /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
+        /// <param name="data">Object to be sent with DELETE. Takes precedence over HttpContent, MultipartFormDataContent, and MultipartContent if more than one is used.</param>
+        /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <returns></returns>
+        public Task<TResult> DeleteAsync<TResult>(string relativeUrl, Enum httpClientName, List<(string Parameter, string Value)>? queryParameters = null);
+
+        /// <summary>
+        /// Clears existing token currently stored in Redis.
+        /// </summary>
+        /// <param name="tokeName">Name of token stored in Redis.</param>
+        /// <returns></returns>
+        public Task<bool> ClearToken(string tokeName);
+    }
+}

--- a/Roo.Azure.Configuration.Common.Http/Models/AuthenticationInfo.cs
+++ b/Roo.Azure.Configuration.Common.Http/Models/AuthenticationInfo.cs
@@ -1,0 +1,132 @@
+﻿using Azure.Core;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Roo.Azure.Configuration.Common.Http.Models
+{
+    /// <summary>
+    /// Required for APIM and OAuth authentication platforms.<br/>
+    /// Properties state which authentication strategy requires them.<br/>
+    /// If no strategy is listed then it's used by all.
+    /// </summary>
+    public class AuthenticationInfo
+    {
+        /// <summary>
+        /// Required.
+        /// Authentication strategy to get token; OAuth, APIM certificate, APIM client secret, or basic.<br/>
+        /// </summary>
+        public AuthenticationStrategy AuthenticationStrategy { get; set; } = 0;
+
+        /// <summary>
+        /// Login id used for all authentication strategies:<br/>
+        /// OAuth: Username<br/>
+        /// ApimCertificate: Azure Active Directory client-id<br/>
+        /// ApimClientSecret: Azure Active Directory client-id
+        /// </summary>
+        public string? LoginId { get; set; } = null;
+
+        /// <summary>
+        /// Password for authentication<br/>
+        /// Used by authentication strategy: OAuth
+        /// </summary>
+        public string? Password { get; set; } = null;
+
+        /// <summary>
+        /// URL to request a token from. If authentication client base URL isn't configured in startup you must pass the URL including the base, otherwise only pass the relative.<br/>
+        /// Used by authentication strategy: OAuth and Basic
+        /// </summary>
+        public string? TokenUrl { get; set; } = null;
+
+        /// <summary>
+        /// Name of client to use for authentication if a client is configured for it in startup.<br/>
+        /// Used by authentication strategy: OAuth and Basic
+        /// </summary>
+        public string? AuthenticationHttpClientName { get; set; } = null;
+
+        /// <summary>
+        /// Azure APIM scope<br/>
+        /// Used by authentication strategy: ApimCertificate and ApimClientSecret
+        /// </summary>
+        public string? ApimScope { get; set; } = null;
+
+        /// <summary>
+        /// Azure APIM subscription key<br/>
+        /// Used by authentication strategy: ApimCertificate and ApimClientSecret
+        /// </summary>
+        public string? ApimSubscriptionKey { get; set; } = null;
+
+        /// <summary>
+        /// Azure APIM tenant id<br/>
+        /// Used by authentication strategy: ApimCertificate and ApimClientSecret
+        /// </summary>
+        public string? ApimTenantId { get; set; } = null;
+
+        /// <summary>
+        /// Name of certificate stored in Azure Key Vault for APIM authentication<br/>
+        /// Used by authentication strategy: ApimCertificate (via Azure Key Vault)
+        /// </summary>
+        public string? ApimCertificateName { get; set; } = null;
+
+        /// <summary>
+        /// Uri of Azure Key Vault that stores the certificate for APIM authentication<br/>
+        /// Used by authentication strategy: ApimCertificate (via Azure Key Vault)
+        /// </summary>
+        public string? ApimAzureKeyVaultUri { get; set; } = null;
+
+        /// <summary>
+        /// Token credential with Certificate Read access to the Azure Key Vault<br/>
+        /// Used by authentication strategy: ApimCertificate (via Azure Key Vault)
+        /// </summary>
+        public TokenCredential? ApimAzureToken { get; set; } = null;
+
+        /// <summary>
+        /// Certificate to use for APIM authentication if the certificate isn't stored in Azure Key Vault<br/>
+        /// Used by authentication strategy: ApimCertificate (via direct certificate)
+        /// </summary>
+        public X509Certificate2? ApimCertificate { get; set; } = null;
+
+        /// <summary>
+        /// Certificate as a string with RSA password to use for APIM authentication if the certificate isn't stored in Azure Key Vault<br/>
+        /// Used by authentication strategy: ApimCertificate (via generating certificate)
+        /// </summary>
+        public (string Certificate, string Password)? ApimCertificateStringAndPassword { get; set; } = null;
+
+        /// <summary>
+        /// APIM client secret for APIM authentication<br/>
+        /// Used by authentication strategy: ApimClientSecret
+        /// </summary>
+        public string? ApimClientSecret { get; set; } = null;
+
+        /// <summary>
+        /// Encoded content to send with the authentication request<br/>
+        /// Used by authentication strategy: Basic
+        /// </summary>
+        public List<(string Name, string Value)>? BasicEncodedContent { get; set; } = null;
+
+        /// <summary>
+        /// APIM client secret for APIM authentication<br/>
+        /// Used by authentication strategy: PassInToken
+        /// </summary>
+        public string? Token { get; set; } = null;
+
+        /// <summary>
+        /// Name for storing token in the cache, overrides HttpClientName
+        /// </summary>
+        public string? TokenName { get; set; }
+
+        /// <summary>
+        /// Force new token generation, will delete cached token and create a new one
+        /// </summary>
+        public bool ForceToken { get; set; } = false;
+
+        /// <summary>
+        /// Add additional headers to the HTTP request. If a header is needed in both the request and authentication, add it to both Lists.
+        /// </summary>
+        public List<(string Name, string Value)>? AdditionalRequestHeaders { get; set; } = null;
+
+        /// <summary>
+        /// Add additional headers required for specific authentication strategies.If a header is needed in both the request and authentication, add it to both Lists.<br/>
+        /// Can be used by authentication strategy: OAuth and Basic
+        /// </summary>
+        public List<(string Name, string Value)>? AuthenticationHeaders { get; set; } = null;
+    }
+}

--- a/Roo.Azure.Configuration.Common.Http/Models/AuthenticationStrategy.cs
+++ b/Roo.Azure.Configuration.Common.Http/Models/AuthenticationStrategy.cs
@@ -1,0 +1,39 @@
+﻿namespace Roo.Azure.Configuration.Common.Http.Models
+{
+    /// <summary>
+    /// Authentication strategies to use when making a request.
+    /// </summary>
+    public enum AuthenticationStrategy
+    {
+        /// <summary>
+        /// No authentication needed
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Authentication using OAuth
+        /// </summary>
+        OAuth = 1,
+
+        /// <summary>
+        /// APIM authentication using a certificate
+        /// </summary>
+        ApimCertificate = 2,
+
+        /// <summary>
+        /// APIM authentication using a client secret
+        /// </summary>
+        ApimClientSecret = 3,
+
+        /// <summary>
+        /// Basic authentication. Pass in the token url, headers, encoded content, and auth client name (optional).<br/>
+        /// Expiration time in cache will be set to 59 minutes.
+        /// </summary>
+        Basic = 4,
+
+        /// <summary>
+        /// Use if you're handling authentication and only passing the token to the request
+        /// </summary>
+        PassInToken = 5
+    }
+}

--- a/Roo.Azure.Configuration.Common.Http/Models/AzureAdTokenResponse.cs
+++ b/Roo.Azure.Configuration.Common.Http/Models/AzureAdTokenResponse.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+
+namespace Roo.Azure.Configuration.Common.Http.Models
+{
+    internal class AzureAdTokenResponse
+    {
+        [JsonProperty("token_type")]
+        public string TokenType { get; set; } = "";
+
+        [JsonProperty("expires_in")]
+        public int ExpiresIn { get; set; }
+
+        [JsonProperty("ext_expires_in")]
+        public int ExtExpiresIn { get; set; }
+
+        [JsonProperty("access_token")]
+        public string AccessToken { get; set; } = "";
+    }
+}

--- a/Roo.Azure.Configuration.Common.Http/Models/BaseTokenResponse.cs
+++ b/Roo.Azure.Configuration.Common.Http/Models/BaseTokenResponse.cs
@@ -1,0 +1,18 @@
+﻿namespace Roo.Azure.Configuration.Common.Http.Models
+{
+    /// <summary>
+    /// Base class for token response models
+    /// </summary>
+    public class BaseTokenResponse
+    {
+        /// <summary>
+        /// Authenticated token
+        /// </summary>
+        public string? Access_Token { get; set; }
+
+        /// <summary>
+        /// Type of token
+        /// </summary>
+        public string? Token_Type { get; set; }
+    }
+}

--- a/Roo.Azure.Configuration.Common.Http/Models/BasicTokenResponse.cs
+++ b/Roo.Azure.Configuration.Common.Http/Models/BasicTokenResponse.cs
@@ -1,0 +1,13 @@
+﻿namespace Roo.Azure.Configuration.Common.Http.Models
+{
+    /// <summary>
+    /// Token response for Basic
+    /// </summary>
+    public class BasicTokenResponse : BaseTokenResponse
+    {
+        /// <summary>
+        /// Token expiration time
+        /// </summary>
+        public long Expires { get; set; }
+    }
+}

--- a/Roo.Azure.Configuration.Common.Http/Models/OAuthTokenResponse.cs
+++ b/Roo.Azure.Configuration.Common.Http/Models/OAuthTokenResponse.cs
@@ -1,0 +1,18 @@
+﻿namespace Roo.Azure.Configuration.Common.Http.Models
+{
+    /// <summary>
+    /// Token response for OAuth
+    /// </summary>
+    public class OAuthTokenResponse : BaseTokenResponse
+    {
+        /// <summary>
+        /// Time till token expires
+        /// </summary>
+        public int Expires_In { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public string? RefreshToken { get; set; }
+    }
+}

--- a/Roo.Azure.Configuration.Common.Http/Models/SerializationSettings.cs
+++ b/Roo.Azure.Configuration.Common.Http/Models/SerializationSettings.cs
@@ -1,0 +1,38 @@
+﻿using Newtonsoft.Json;
+using System.Text.Json;
+
+namespace Roo.Azure.Configuration.Common.Http.Models
+{
+    /// <summary>
+    /// Use to edit settings for serialilzing HTTP responses
+    /// </summary>
+    public class SerializationSettings
+    {
+        /// <summary>
+        /// Read response as a string when serializing
+        /// </summary>
+        public bool ReadAsString { get; set; } = false;
+
+        /// <summary>
+        /// Use default System.Text.Json serialization settings. Default settings:<br/>
+        /// <list type="bullet">
+        /// <item>ContractResolver = new CamelCasePropertyNamesContractResolver()</item>
+        /// <item>DateTimeZoneHandling = DateTimeZoneHandling.Local</item>
+        /// <item>NullValueHandling = NullValueHandling.Ignore</item>
+        /// </list>
+        /// </summary>
+        public bool UseDefaultSerializationSettings { get; set; } = false;
+
+        /// <summary>
+        /// Newtonsoft.Json serializer settings.<br/>
+        /// Will override default settings if UseDefaultSerializationSettings is set to true.
+        /// </summary>
+        public JsonSerializerSettings? JsonSerializerSettings { get; set; } = null;
+
+        /// <summary>
+        /// System.Text.Json serializer settings.<br/>
+        /// Will override default settings if UseDefaultSerializationSettings is set to true.
+        /// </summary>
+        public JsonSerializerOptions? JsonSerializerOptions { get; set; } = null;
+    }
+}

--- a/Roo.Azure.Configuration.Common.Http/Roo.Azure.Configuration.Common.Http.csproj
+++ b/Roo.Azure.Configuration.Common.Http/Roo.Azure.Configuration.Common.Http.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.14.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.8.0" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.17" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Polly" Version="8.6.1" />
+    <PackageReference Include="Polly.Caching.Memory" Version="3.0.2" />
+    <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Roo.Azure.Configuration.Common\Roo.Azure.Configuration.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Roo.Azure.Configuration.Common.Http/RooHttpClient.cs
+++ b/Roo.Azure.Configuration.Common.Http/RooHttpClient.cs
@@ -1,0 +1,892 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Primitives;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
+using Roo.Azure.Configuration.Common.Http.AzureAdAuthentication;
+using Roo.Azure.Configuration.Common.Http.Models;
+using Roo.Azure.Configuration.Common.Logging;
+using Roo.Azure.Configuration.Common.Models;
+using Roo.Azure.Configuration.Common.Services;
+using System.Data;
+using System.Net;
+using System.Security.Claims;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace Roo.Azure.Configuration.Common.Http
+{
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    public class RooHttpClient : IRooHttpClient
+    {
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        public HttpContext? HttpContext { get; set; } = null;
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        public string? SessionId { get; set; } = null;
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        public string? TransactionId { get; set; } = null;
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        public string? ChannelId { get; set; } = null;
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        public UserInfo? UserInfo { get; set; } = null;
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        public AuthenticationInfo? AuthenticationInfo { get; set; } = null;
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        public SerializationSettings? SerializationSettings { get; set; }
+
+        private static readonly SemaphoreSlim _semaphoreSlim = new SemaphoreSlim(1, 1);
+        private readonly string _channelId;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly IRooLogger _logger;
+        private readonly IAzureAdClientAssertion _azureAdClientAssertion;
+        private readonly IRedisService? _redisService;
+        private readonly IMemoryCache? _cache;
+
+        /// <summary>
+        /// Initialize class with configuration
+        /// </summary>
+        /// <param name="channelId"></param>
+        /// <param name="httpContextAccessor"></param>
+        /// <param name="httpClientFactory"></param>
+        /// <param name="logger"></param>
+        /// <param name="redisService"></param>
+        public RooHttpClient(string channelId, IHttpContextAccessor httpContextAccessor, IHttpClientFactory httpClientFactory, IRooLogger logger, IAzureAdClientAssertion azureAdClientAssertion)
+        {
+            _channelId = channelId;
+            _httpContextAccessor = httpContextAccessor;
+            _httpClientFactory = httpClientFactory;
+            _logger = logger;
+            _azureAdClientAssertion = azureAdClientAssertion;
+        }
+
+        /// <summary>
+        /// Initialize class with configuration with Redis
+        /// </summary>
+        /// <param name="channelId"></param>
+        /// <param name="httpContextAccessor"></param>
+        /// <param name="httpClientFactory"></param>
+        /// <param name="logger"></param>
+        /// <param name="redisService"></param>
+        public RooHttpClient(string channelId, IHttpContextAccessor httpContextAccessor, IHttpClientFactory httpClientFactory, IRooLogger logger, IAzureAdClientAssertion azureAdClientAssertion, IRedisService redisService)
+        {
+            _channelId = channelId;
+            _httpContextAccessor = httpContextAccessor;
+            _httpClientFactory = httpClientFactory;
+            _logger = logger;
+            _azureAdClientAssertion = azureAdClientAssertion;
+            _redisService = redisService;
+        }
+
+        /// <summary>
+        /// Initialize class with configuration with in memory cache
+        /// </summary>
+        /// <param name="channelId"></param>
+        /// <param name="httpContextAccessor"></param>
+        /// <param name="httpClientFactory"></param>
+        /// <param name="logger"></param>
+        /// <param name="redisService"></param>
+        public RooHttpClient(string channelId, IHttpContextAccessor httpContextAccessor, IHttpClientFactory httpClientFactory, IRooLogger logger, IAzureAdClientAssertion azureAdClientAssertion, IMemoryCache cache)
+        {
+            _channelId = channelId;
+            _httpContextAccessor = httpContextAccessor;
+            _httpClientFactory = httpClientFactory;
+            _logger = logger;
+            _azureAdClientAssertion = azureAdClientAssertion;
+            _cache = cache;
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <param name="relativeUrl"></param>
+        /// <param name="httpClientName"></param>
+        /// <param name="queryParameters"></param>
+        /// <returns></returns>
+        public async Task<HttpResponseMessage> GetAsync(string relativeUrl, string httpClientName, List<(string Parameter, string Value)>? queryParameters = null)
+        {
+            if (queryParameters != null)
+            {
+                relativeUrl += ToQueryString(queryParameters);
+            }
+            var httpClient = await HttpClientSetup(httpClientName).ConfigureAwait(false);
+            var response = await httpClient.GetAsync(relativeUrl).ConfigureAwait(false);
+            if (response.StatusCode == HttpStatusCode.Unauthorized && AuthenticationInfo != null)
+            {
+                AddBearerToken(await GetToken(httpClientName, true).ConfigureAwait(false) ?? "", httpClient);
+                response = await httpClient.GetAsync(relativeUrl).ConfigureAwait(false);
+            }
+            return response;
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <param name="relativeUrl"></param>
+        /// <param name="httpClientName"></param>
+        /// <param name="queryStringObject"></param>
+        /// <returns></returns>
+        public async Task<HttpResponseMessage> GetAsync(string relativeUrl, string httpClientName, object queryStringObject)
+        {
+            relativeUrl += ToQueryString(queryStringObject);
+            var response = await GetAsync(relativeUrl, httpClientName).ConfigureAwait(false);
+            return response;
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <typeparam name="TResult"></typeparam>
+        /// <param name="relativeUrl"></param>
+        /// <param name="httpClientName"></param>
+        /// <param name="queryParameters"></param>
+        /// <returns></returns>
+        public async Task<TResult> GetAsync<TResult>(string relativeUrl, string httpClientName, List<(string Parameter, string Value)>? queryParameters = null)
+        {
+            var response = await GetAsync(relativeUrl, httpClientName, queryParameters).ConfigureAwait(false);
+            return await DeserializeResult<TResult>(response).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <typeparam name="TResult"></typeparam>
+        /// <param name="relativeUrl"></param>
+        /// <param name="httpClientName"></param>
+        /// <param name="queryStringObject"></param>
+        /// <returns></returns>
+        public async Task<TResult> GetAsync<TResult>(string relativeUrl, string httpClientName, object queryStringObject)
+        {
+            relativeUrl += ToQueryString(queryStringObject);
+            var response = await GetAsync(relativeUrl, httpClientName).ConfigureAwait(false);
+            return await DeserializeResult<TResult>(response).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <param name="relativeUrl"></param>
+        /// <param name="httpClientName"></param>
+        /// <param name="queryParameters"></param>
+        /// <returns></returns>
+        public async Task<HttpResponseMessage> GetAsync(string relativeUrl, Enum httpClientName, List<(string Parameter, string Value)>? queryParameters = null)
+        {
+            return await GetAsync(relativeUrl, httpClientName.ToString(), queryParameters).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <param name="relativeUrl"></param>
+        /// <param name="httpClientName"></param>
+        /// <param name="queryStringObject"></param>
+        /// <returns></returns>
+        public async Task<HttpResponseMessage> GetAsync(string relativeUrl, Enum httpClientName, object queryStringObject)
+        {
+            return await GetAsync(relativeUrl, httpClientName.ToString(), queryStringObject).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <typeparam name="TResult"></typeparam>
+        /// <param name="relativeUrl"></param>
+        /// <param name="httpClientName"></param>
+        /// <param name="queryParameters"></param>
+        /// <returns></returns>
+        public async Task<TResult> GetAsync<TResult>(string relativeUrl, Enum httpClientName, List<(string Parameter, string Value)>? queryParameters = null)
+        {
+            return await GetAsync<TResult>(relativeUrl, httpClientName.ToString(), queryParameters).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <typeparam name="TResult"></typeparam>
+        /// <param name="relativeUrl"></param>
+        /// <param name="httpClientName"></param>
+        /// <param name="queryStringObject"></param>
+        /// <returns></returns>
+        public async Task<TResult> GetAsync<TResult>(string relativeUrl, Enum httpClientName, object queryStringObject)
+        {
+            return await GetAsync<TResult>(relativeUrl, httpClientName.ToString(), queryStringObject).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <param name="relativeUrl"></param>
+        /// <param name="httpClientName"></param>
+        /// <param name="data"></param>
+        /// <param name="queryParameters"></param>
+        /// <returns></returns>
+        public async Task<HttpResponseMessage> PostAsync(string relativeUrl, string httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null)
+        {
+            HttpContent? content = null;
+            if (data != null)
+            {
+                if (data is not HttpContent && data is not MultipartFormDataContent && data is not MultipartContent)
+                {
+                    content = new StringContent(JsonConvert.SerializeObject(data));
+                    content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+                }
+                else
+                {
+                    if (data is HttpContent)
+                    {
+                        content = (HttpContent?)data;
+                    }
+                    else if (data is MultipartFormDataContent)
+                    {
+                        content = (MultipartFormDataContent?)data;
+                    }
+                    else if (data is MultipartContent)
+                    {
+                        content = (MultipartContent?)data;
+                    }
+                }
+            }
+            if (queryParameters != null)
+            {
+                relativeUrl += ToQueryString(queryParameters);
+            }
+            var httpClient = await HttpClientSetup(httpClientName).ConfigureAwait(false);
+            var response = await httpClient.PostAsync(relativeUrl, content).ConfigureAwait(false);
+            if (response.StatusCode == HttpStatusCode.Unauthorized && AuthenticationInfo != null)
+            {
+                AddBearerToken(await GetToken(httpClientName, true).ConfigureAwait(false) ?? "", httpClient);
+                response = await httpClient.PostAsync(relativeUrl, content).ConfigureAwait(false);
+            }
+            return response;
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <typeparam name="TResult"></typeparam>
+        /// <param name="relativeUrl"></param>
+        /// <param name="httpClientName"></param>
+        /// <param name="data"></param>
+        /// <param name="queryParameters"></param>
+        /// <returns></returns>
+        public async Task<TResult> PostAsync<TResult>(string relativeUrl, string httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null)
+        {
+            var response = await PostAsync(relativeUrl, httpClientName, data, queryParameters).ConfigureAwait(false);
+            return await DeserializeResult<TResult>(response).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <param name="relativeUrl"></param>
+        /// <param name="httpClientName"></param>
+        /// <param name="data"></param>
+        /// <param name="queryParameters"></param>
+        /// <returns></returns>
+        public async Task<HttpResponseMessage> PostAsync(string relativeUrl, Enum httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null)
+        {
+            return await PostAsync(relativeUrl, httpClientName.ToString(), data, queryParameters).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <typeparam name="TResult"></typeparam>
+        /// <param name="relativeUrl"></param>
+        /// <param name="httpClientName"></param>
+        /// <param name="data"></param>
+        /// <param name="queryParameters"></param>
+        /// <returns></returns>
+        public async Task<TResult> PostAsync<TResult>(string relativeUrl, Enum httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null)
+        {
+            return await PostAsync<TResult>(relativeUrl, httpClientName.ToString(), data, queryParameters).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <param name="relativeUrl"></param>
+        /// <param name="httpClientName"></param>
+        /// <param name="data"></param>
+        /// <param name="queryParameters"></param>
+        /// <returns></returns>
+        public async Task<HttpResponseMessage> PutAsync(string relativeUrl, string httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null)
+        {
+            HttpContent? content = null;
+            if (data != null)
+            {
+                if (data is not HttpContent && data is not MultipartFormDataContent && data is not MultipartContent)
+                {
+                    content = new StringContent(JsonConvert.SerializeObject(data));
+                    content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+                }
+                else
+                {
+                    if (data is HttpContent)
+                    {
+                        content = (HttpContent?)data;
+                    }
+                    else if (data is MultipartFormDataContent)
+                    {
+                        content = (MultipartFormDataContent?)data;
+                    }
+                    else if (data is MultipartContent)
+                    {
+                        content = (MultipartContent?)data;
+                    }
+                }
+            }
+            if (queryParameters != null)
+            {
+                relativeUrl += ToQueryString(queryParameters);
+            }
+            var httpClient = await HttpClientSetup(httpClientName).ConfigureAwait(false);
+            var response = await httpClient.PutAsync(relativeUrl, content).ConfigureAwait(false);
+            if (response.StatusCode == HttpStatusCode.Unauthorized && AuthenticationInfo != null)
+            {
+                AddBearerToken(await GetToken(httpClientName, true).ConfigureAwait(false) ?? "", httpClient);
+                response = await httpClient.PutAsync(relativeUrl, content).ConfigureAwait(false);
+            }
+            return response;
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <typeparam name="TResult"></typeparam>
+        /// <param name="relativeUrl"></param>
+        /// <param name="httpClientName"></param>
+        /// <param name="data"></param>
+        /// <param name="queryParameters"></param>
+        /// <returns></returns>
+        public async Task<TResult> PutAsync<TResult>(string relativeUrl, string httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null)
+        {
+            var response = await PutAsync(relativeUrl, httpClientName, data, queryParameters).ConfigureAwait(false);
+            return await DeserializeResult<TResult>(response).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <param name="relativeUrl"></param>
+        /// <param name="httpClientName"></param>
+        /// <param name="data"></param>
+        /// <param name="queryParameters"></param>
+        /// <returns></returns>
+        public async Task<HttpResponseMessage> PutAsync(string relativeUrl, Enum httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null)
+        {
+            return await PutAsync(relativeUrl, httpClientName.ToString(), data, queryParameters).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <typeparam name="TResult"></typeparam>
+        /// <param name="relativeUrl"></param>
+        /// <param name="httpClientName"></param>
+        /// <param name="data"></param>
+        /// <param name="queryParameters"></param>
+        /// <returns></returns>
+        public async Task<TResult> PutAsync<TResult>(string relativeUrl, Enum httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null)
+        {
+            return await PutAsync<TResult>(relativeUrl, httpClientName.ToString(), data, queryParameters).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <param name="relativeUrl"></param>
+        /// <param name="httpClientName"></param>
+        /// <param name="queryParameters"></param>
+        /// <returns></returns>
+        public async Task<HttpResponseMessage> DeleteAsync(string relativeUrl, string httpClientName, List<(string Parameter, string Value)>? queryParameters = null)
+        {
+            if (queryParameters != null)
+            {
+                relativeUrl += ToQueryString(queryParameters);
+            }
+            var httpClient = await HttpClientSetup(httpClientName).ConfigureAwait(false);
+            var response = await httpClient.DeleteAsync(relativeUrl).ConfigureAwait(false);
+            if (response.StatusCode == HttpStatusCode.Unauthorized && AuthenticationInfo != null)
+            {
+                AddBearerToken(await GetToken(httpClientName, true).ConfigureAwait(false) ?? "", httpClient);
+                response = await httpClient.DeleteAsync(relativeUrl).ConfigureAwait(false);
+            }
+            return response;
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <typeparam name="TResult"></typeparam>
+        /// <param name="relativeUrl"></param>
+        /// <param name="httpClientName"></param>
+        /// <param name="queryParameters"></param>
+        /// <returns></returns>
+        public async Task<TResult> DeleteAsync<TResult>(string relativeUrl, string httpClientName, List<(string Parameter, string Value)>? queryParameters = null)
+        {
+            var response = await DeleteAsync(relativeUrl, httpClientName, queryParameters).ConfigureAwait(false);
+            return await DeserializeResult<TResult>(response).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <param name="relativeUrl"></param>
+        /// <param name="httpClientName"></param>
+        /// <param name="queryParameters"></param>
+        /// <returns></returns>
+        public async Task<HttpResponseMessage> DeleteAsync(string relativeUrl, Enum httpClientName, List<(string Parameter, string Value)>? queryParameters = null)
+        {
+            return await DeleteAsync(relativeUrl, httpClientName.ToString(), queryParameters).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <typeparam name="TResult"></typeparam>
+        /// <param name="relativeUrl"></param>
+        /// <param name="httpClientName"></param>
+        /// <param name="queryParameters"></param>
+        /// <returns></returns>
+        public async Task<TResult> DeleteAsync<TResult>(string relativeUrl, Enum httpClientName, List<(string Parameter, string Value)>? queryParameters = null)
+        {
+            return await DeleteAsync<TResult>(relativeUrl, httpClientName.ToString(), queryParameters).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <param name="tokenName"></param>
+        /// <returns></returns>
+        public async Task<bool> ClearToken(string? tokenName = null)
+        {
+            if (_redisService == null && _cache == null)
+            {
+                return false;
+            }
+            var key = tokenName ?? AuthenticationInfo?.TokenName;
+            if (string.IsNullOrEmpty(key))
+            {
+                return false;
+            }
+            if (_redisService != null)
+            {
+                return await _redisService.Delete(key).ConfigureAwait(false);
+            }
+            if (_cache != null)
+            {
+                _cache.Remove(key);
+                return true;
+            }
+            return false;
+        }
+
+        private async Task<HttpClient> HttpClientSetup(string httpClientName)
+        {
+            if (HttpContext == null)
+            {
+                HttpContext = _httpContextAccessor.HttpContext;
+            }
+
+            var httpClient = CreateHttpClient(httpClientName);
+
+            AddBearerToken(await GetToken(httpClientName).ConfigureAwait(false) ?? "", httpClient);
+
+            AddHeaderParameters(httpClient);
+
+            return httpClient;
+        }
+
+        private HttpClient CreateHttpClient(string httpClientName)
+        {
+            return _httpClientFactory.CreateClient(httpClientName);
+        }
+
+        private async Task<TResult> DeserializeResult<TResult>(HttpResponseMessage response)
+        {
+            if (SerializationSettings != null && SerializationSettings.JsonSerializerOptions != null)
+            {
+                try
+                {
+                    if (SerializationSettings.ReadAsString)
+                    {
+                        var contentString = await response.Content.SafeReadAsStringAsync().ConfigureAwait(false);
+                        if (string.IsNullOrEmpty(contentString))
+                        {
+                            return default!;
+                        }
+                        return System.Text.Json.JsonSerializer.Deserialize<TResult>(contentString, SerializationSettings.JsonSerializerOptions) ?? default!;
+                    }
+                    var contentStream = await response.Content.SafeReadAsStreamAsync().ConfigureAwait(false);
+                    if (contentStream == null)
+                    {
+                        return default!;
+                    }
+                    return System.Text.Json.JsonSerializer.Deserialize<TResult>(contentStream, SerializationSettings.JsonSerializerOptions) ?? default!;
+                }
+                catch
+                {
+                    return default!;
+                }
+            }
+
+            JsonSerializerSettings? serializerSettings = null;
+            if (SerializationSettings != null && SerializationSettings.UseDefaultSerializationSettings)
+            {
+                serializerSettings = new JsonSerializerSettings
+                {
+                    ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                    DateTimeZoneHandling = DateTimeZoneHandling.Local,
+                    NullValueHandling = NullValueHandling.Ignore
+                };
+                serializerSettings.Converters.Add(new StringEnumConverter());
+            }
+
+            try
+            {
+                if (SerializationSettings != null && SerializationSettings.ReadAsString)
+                {
+                    var contentString = await response.Content.SafeReadAsStringAsync().ConfigureAwait(false);
+                    if (string.IsNullOrEmpty(contentString))
+                    {
+                        return default!;
+                    }
+                    return JsonConvert.DeserializeObject<TResult>(contentString, SerializationSettings.JsonSerializerSettings ?? serializerSettings) ?? default!;
+                }
+                using (var json = new JsonTextReader(new StreamReader(await response.Content.SafeReadAsStreamAsync().ConfigureAwait(false) ?? default!)))
+                {
+                    var serializer = JsonSerializer.Create(SerializationSettings?.JsonSerializerSettings ?? serializerSettings);
+                    return serializer.Deserialize<TResult>(json) ?? default!;
+                }
+            }
+            catch
+            {
+                return default!;
+            }
+        }
+
+        private void AddHeaderParameters(HttpClient httpClient)
+        {
+            if (AuthenticationInfo != null)
+            {
+                if (AuthenticationInfo.AdditionalRequestHeaders != null)
+                {
+                    foreach (var header in AuthenticationInfo.AdditionalRequestHeaders)
+                    {
+                        httpClient.DefaultRequestHeaders.TryAddWithoutValidation(header.Name, header.Value);
+                    }
+                }
+
+                if (AuthenticationInfo != null && (AuthenticationInfo.AuthenticationStrategy == AuthenticationStrategy.ApimCertificate || AuthenticationInfo.AuthenticationStrategy == AuthenticationStrategy.ApimClientSecret))
+                {
+                    httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Ocp-Apim-Subscription-Key", AuthenticationInfo.ApimSubscriptionKey);
+                }
+            }
+
+            //Incoming request headers
+            var incomingHeaders = HttpContext?.Request.Headers;
+
+            //Add session-id from incoming request to outgoing request
+            var values = new StringValues();
+            incomingHeaders?.TryGetValue(Constants.SessionIdHeaderName, out values);
+            httpClient.DefaultRequestHeaders.Remove(Constants.SessionIdHeaderName);
+            httpClient.DefaultRequestHeaders.TryAddWithoutValidation(Constants.SessionIdHeaderName, SessionId ?? (values.Count > 0 ? values[0] : null) ?? _httpContextAccessor.HttpContext?.Session.GetString(Constants.SessionId) ?? _httpContextAccessor.HttpContext?.Session.Id ?? Guid.NewGuid().ToString());
+
+            //Add new transaction-id to outgoing request
+            httpClient.DefaultRequestHeaders.Remove(Constants.TransactionIdHeaderName);
+            httpClient.DefaultRequestHeaders.TryAddWithoutValidation(Constants.TransactionIdHeaderName, TransactionId ?? Guid.NewGuid().ToString("N"));
+
+            //Add channel-id of current application to outgoing request
+            httpClient.DefaultRequestHeaders.Remove(Constants.ChannelIdHeaderName);
+            httpClient.DefaultRequestHeaders.TryAddWithoutValidation(Constants.ChannelIdHeaderName, ChannelId ?? _channelId);
+
+            //Add user-info from incoming request to outgoing request or if the current application has claims
+            if (UserInfo != null || (HttpContext != null && HttpContext.User.Claims.Any()))
+            {
+                var userInfoValues = new StringValues();
+                incomingHeaders?.TryGetValue(Constants.UserInfoHeaderName, out userInfoValues);
+
+                UserInfo? userInfo = null;
+                if (userInfoValues.Count == 0 || UserInfo != null)
+                {
+                    userInfo = new()
+                    {
+                        LoginId = UserInfo?.LoginId ?? HttpContext?.User.FindFirstValue(Constants.UserInfoUsername),
+                        Email = UserInfo?.Email ?? HttpContext?.User.FindFirstValue(ClaimTypes.Email),
+                        UserId = UserInfo?.UserId,
+                        SubId = UserInfo?.SubId,
+                        IsAuthenticated = UserInfo?.IsAuthenticated ?? HttpContext?.User.Identity?.IsAuthenticated ?? false
+                    };
+                }
+                httpClient.DefaultRequestHeaders.Remove(Constants.UserInfoHeaderName);
+                httpClient.DefaultRequestHeaders.TryAddWithoutValidation(Constants.UserInfoHeaderName, userInfo != null ? JsonConvert.SerializeObject(userInfo) : userInfoValues[0]);
+            }
+        }
+
+        private void AddBearerToken(string token, HttpClient client)
+        {
+            if (string.IsNullOrEmpty(token))
+            {
+                return;
+            }
+            client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+        }
+
+        private async Task<string?> GetToken(string httpClientName, bool forceToken = false)
+        {
+            if (AuthenticationInfo == null || string.IsNullOrEmpty(AuthenticationInfo.TokenName))
+            {
+                return null;
+            }
+
+            if (AuthenticationInfo.ForceToken || forceToken)
+            {
+                _logger.LogInformation(HttpContext, "Deleting stored token and requesting a new one.");
+                await ClearToken().ConfigureAwait(false);
+            }
+
+            await _semaphoreSlim.WaitAsync();
+
+            string? token = null;
+            if (_redisService != null)
+            {
+                token = await _redisService.Get(AuthenticationInfo.TokenName ?? httpClientName);
+            }
+            else if (_cache != null)
+            {
+                token = _cache.Get<string>(AuthenticationInfo.TokenName ?? httpClientName);
+            }
+
+            try
+            {
+                if (string.IsNullOrEmpty(token))
+                {
+                    _logger.LogInformation(HttpContext, "Token not found, creating new one.");
+                    ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
+                    if (AuthenticationInfo.AuthenticationStrategy == AuthenticationStrategy.OAuth)
+                    {
+                        token = await GetTokenOAuth(httpClientName);
+                    }
+                    else if (AuthenticationInfo.AuthenticationStrategy == AuthenticationStrategy.ApimCertificate || AuthenticationInfo.AuthenticationStrategy == AuthenticationStrategy.ApimClientSecret)
+                    {
+                        token = await GetTokenApim(httpClientName);
+                    }
+                    else if (AuthenticationInfo.AuthenticationStrategy == AuthenticationStrategy.Basic)
+                    {
+                        token = await GetTokenBasic(httpClientName);
+                    }
+                    else if (AuthenticationInfo.AuthenticationStrategy == AuthenticationStrategy.PassInToken)
+                    {
+                        token = AuthenticationInfo.Token;
+                    }
+                }
+            }
+            finally
+            {
+                _semaphoreSlim.Release();
+            }
+            return token;
+        }
+
+        private async Task<string?> GetTokenOAuth(string httpClientName)
+        {
+            if (AuthenticationInfo == null || string.IsNullOrEmpty(AuthenticationInfo.LoginId) || string.IsNullOrEmpty(AuthenticationInfo.Password) || string.IsNullOrEmpty(AuthenticationInfo.TokenUrl))
+            {
+                return null;
+            }
+
+            var httpClient = CreateHttpClient(AuthenticationInfo.AuthenticationHttpClientName ?? httpClientName);
+            if (AuthenticationInfo.AuthenticationHeaders != null)
+            {
+                foreach (var header in AuthenticationInfo.AuthenticationHeaders)
+                {
+                    httpClient.DefaultRequestHeaders.TryAddWithoutValidation(header.Name, header.Value);
+                }
+            }
+
+            var content = new FormUrlEncodedContent([
+                new KeyValuePair<string, string>("username", AuthenticationInfo.LoginId),
+                new KeyValuePair<string, string>("password", AuthenticationInfo.Password),
+                new KeyValuePair<string, string>("grant_type", "password"),
+            ]);
+            content.Headers.Clear();
+            content.Headers.Add("Content-Type", "application/x-www-form-urlencoded");
+
+            var tokenResponse = await httpClient.PostAsync(AuthenticationInfo.TokenUrl, content);
+            if (tokenResponse.IsSuccessStatusCode)
+            {
+                var token = await tokenResponse.Content.ReadAsAsync<OAuthTokenResponse>();
+                if (token != null && !string.IsNullOrEmpty(token.Access_Token))
+                {
+                    var cacheExpiration = TimeSpan.FromSeconds(token.Expires_In - 60);
+                    if (_redisService != null)
+                    {
+                        await _redisService.Set(AuthenticationInfo.TokenName ?? httpClientName, token.Access_Token, cacheExpiration);
+                        _logger.LogInformation(HttpContext, $"OAuth token stored and expires in: {cacheExpiration}.");
+                    }
+                    else if (_cache != null)
+                    {
+                        _cache.Set(AuthenticationInfo.TokenName ?? httpClientName, token.Access_Token, cacheExpiration);
+                        _logger.LogInformation(HttpContext, $"OAuth token stored and expires in: {cacheExpiration}.");
+                    }
+                    return token.Access_Token;
+                }
+            }
+            _logger.LogError(HttpContext, $"Error getting OAuth token.");
+            return null;
+        }
+
+        private async Task<string?> GetTokenApim(string httpClientName)
+        {
+            if (AuthenticationInfo == null || string.IsNullOrEmpty(AuthenticationInfo.LoginId) || string.IsNullOrEmpty(AuthenticationInfo.ApimTenantId) || string.IsNullOrEmpty(AuthenticationInfo.ApimScope) ||
+                string.IsNullOrEmpty(AuthenticationInfo.ApimSubscriptionKey))
+            {
+                return null;
+            }
+
+            string? token = null;
+            if (AuthenticationInfo.AuthenticationStrategy == AuthenticationStrategy.ApimCertificate)
+            {
+                X509Certificate2? cert = null;
+                if (!string.IsNullOrEmpty(AuthenticationInfo.ApimCertificateName) && !string.IsNullOrEmpty(AuthenticationInfo.ApimAzureKeyVaultUri))
+                {
+                    cert = await _azureAdClientAssertion.GetCertificateFromKeyVault(AuthenticationInfo.ApimCertificateName, AuthenticationInfo.ApimAzureKeyVaultUri, AuthenticationInfo.ApimAzureToken);
+                }
+                else if (AuthenticationInfo.ApimCertificate != null)
+                {
+                    cert = AuthenticationInfo.ApimCertificate;
+                }
+                else if (AuthenticationInfo.ApimCertificateStringAndPassword != null && !string.IsNullOrEmpty(AuthenticationInfo.ApimCertificateStringAndPassword.Value.Certificate) && !string.IsNullOrEmpty(AuthenticationInfo.ApimCertificateStringAndPassword.Value.Password))
+                {
+                    cert = _azureAdClientAssertion.GenerateCertificateFromString(AuthenticationInfo.ApimCertificateStringAndPassword.Value.Certificate, AuthenticationInfo.ApimCertificateStringAndPassword.Value.Password);
+                }
+                if (cert == null)
+                {
+                    _logger.LogInformation(HttpContext, $"Downloading APIM certificate from Azure Key Vault failed. Certificate not found in key vault or unable to download.");
+                    return null;
+                }
+                token = await _azureAdClientAssertion.GetTokenAsync(AuthenticationInfo.ApimTenantId, AuthenticationInfo.LoginId, AuthenticationInfo.ApimScope, cert, AuthenticationInfo.TokenName ?? httpClientName);
+            }
+            else if (AuthenticationInfo.AuthenticationStrategy == AuthenticationStrategy.ApimClientSecret && !string.IsNullOrEmpty(AuthenticationInfo.ApimClientSecret))
+            {
+                token = await _azureAdClientAssertion.GetTokenAsync(AuthenticationInfo.ApimTenantId, AuthenticationInfo.LoginId, AuthenticationInfo.ApimScope, AuthenticationInfo.ApimClientSecret, AuthenticationInfo.TokenName ?? httpClientName);
+            }
+
+            if (!string.IsNullOrEmpty(token))
+            {
+                var cacheExpiration = TimeSpan.FromMinutes(59);
+                if (_redisService != null)
+                {
+                    await _redisService.Set(AuthenticationInfo.TokenName ?? httpClientName, token, cacheExpiration);
+                    _logger.LogInformation(HttpContext, $"Azure APIM access token stored and expires in: {cacheExpiration}.");
+                }
+                else if (_cache != null)
+                {
+                    _cache.Set(AuthenticationInfo.TokenName ?? httpClientName, token, cacheExpiration);
+                    _logger.LogInformation(HttpContext, $"Azure APIM access token stored and expires in: {cacheExpiration}.");
+                }
+                return token;
+            }
+            _logger.LogError(HttpContext, $"Error getting APIM token.");
+            return null;
+        }
+
+        private async Task<string?> GetTokenBasic(string httpClientName)
+        {
+            if (AuthenticationInfo == null || string.IsNullOrEmpty(AuthenticationInfo.TokenUrl))
+            {
+                return null;
+            }
+
+            var httpClient = CreateHttpClient(AuthenticationInfo.AuthenticationHttpClientName ?? httpClientName);
+            if (AuthenticationInfo.AuthenticationHeaders != null)
+            {
+                foreach (var header in AuthenticationInfo.AuthenticationHeaders)
+                {
+                    httpClient.DefaultRequestHeaders.TryAddWithoutValidation(header.Name, header.Value);
+                }
+            }
+            FormUrlEncodedContent? content = null;
+            if (AuthenticationInfo.BasicEncodedContent != null)
+            {
+                var encodedContent = new List<KeyValuePair<string, string>>();
+                foreach (var header in AuthenticationInfo.BasicEncodedContent)
+                {
+                    encodedContent.Add(new(header.Name, header.Value));
+                }
+                content = new FormUrlEncodedContent(encodedContent);
+                content.Headers.Clear();
+                content.Headers.Add("Content-Type", "application/x-www-form-urlencoded");
+            }
+            
+            var tokenResponse = await httpClient.PostAsync(AuthenticationInfo.TokenUrl, content);
+            if (tokenResponse.IsSuccessStatusCode)
+            {
+                var token = await tokenResponse.Content.ReadAsAsync<BasicTokenResponse>();
+                if (token != null && !string.IsNullOrEmpty(token.Access_Token))
+                {
+                    var cacheExpiration = TimeSpan.FromSeconds(59);
+                    if (_redisService != null)
+                    {
+                        await _redisService.Set(AuthenticationInfo.TokenName ?? httpClientName, token.Access_Token, cacheExpiration);
+                        _logger.LogInformation(HttpContext, $"Basic token stored and expires in: {cacheExpiration}.");
+                    }
+                    else if (_cache != null)
+                    {
+                        _cache.Set(AuthenticationInfo.TokenName ?? httpClientName, token.Access_Token, cacheExpiration);
+                        _logger.LogInformation(HttpContext, $"Basic token stored and expires in: {cacheExpiration}.");
+                    }
+                    return token.Access_Token;
+                }
+            }
+            _logger.LogError(HttpContext, $"Error getting Basic token.");
+            return null;
+        }
+
+        private static string ToQueryString(object obj)
+        {
+            var s = new StringBuilder("?");
+            var objType = obj.GetType();
+            objType.GetProperties().Where(x => x.GetValue(obj, null) != null).ToList().ForEach(x => s.Append($"{Uri.EscapeDataString(x.Name)}={Uri.EscapeDataString(x.GetValue(obj)?.ToString() ?? "")}&"));
+            s.Length--;
+            return s.ToString();
+        }
+
+        private static string ToQueryString(List<(string Parameter, string Value)> queryParameters)
+        {
+            var s = new StringBuilder("?");
+            foreach (var queryParameter in queryParameters)
+            {
+                s.Append($"{Uri.EscapeDataString(queryParameter.Parameter)}={Uri.EscapeDataString(queryParameter.Value)}&");
+                
+            }
+            s.Length--;
+            return s.ToString();
+        }
+    }
+}

--- a/Roo.Azure.Configuration.Common.Http/RooHttpClientConfiguration.cs
+++ b/Roo.Azure.Configuration.Common.Http/RooHttpClientConfiguration.cs
@@ -1,0 +1,115 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Roo.Azure.Configuration.Common.Http.AzureAdAuthentication;
+using Roo.Azure.Configuration.Common.Logging;
+using Roo.Azure.Configuration.Common.Middlewares;
+using Roo.Azure.Configuration.Common.Services;
+
+namespace Roo.Azure.Configuration.Common.Http
+{
+    /// <summary>
+    /// Configure RooHttpClient in program startup.
+    /// </summary>
+    public static class RooHttpClientConfiguration
+    {
+        /// <summary>
+        /// Configures a RooHttpClient and creates named HttpClients for every clientList item with the accompanying base URL.
+        /// </summary>
+        /// <param name="services"></param>
+        /// <param name="channelId">Channel Id of application.</param>
+        /// <param name="httpClients">List of HttpClient names (as strings) and base URLs to configure.</param>
+        /// <param name="useMemoryCache">Whether to use memory cache when storing tokens. Redis takes precedence if Redis connection string is passed in.</param>
+        /// <param name="redisConnectionString">Connection string to Redis, controls whether to use Redis when storing tokens. Takes precedence over memory cache.</param>
+        /// <param name=""></param>
+        /// <returns></returns>
+        public static IServiceCollection RooHttpClientConfig(this IServiceCollection services, string channelId, List<(string Name, string BaseUrl)> httpClients, bool useMemoryCache = false, string? redisConnectionString = null)
+        {
+            //Iterate through client list and create named client for each item
+            foreach (var httpClient in httpClients)
+            {
+                if (string.IsNullOrEmpty(httpClient.Name) || string.IsNullOrEmpty(httpClient.BaseUrl))
+                {
+                    continue;
+                }
+                services.AddHttpClient(httpClient.Name, config =>
+                {
+                    config.BaseAddress = new Uri(httpClient.BaseUrl);
+                }).AddHttpMessageHandler<HeaderPropagateMiddleware>();
+            }
+            return CreateHttpClient(services, channelId, useMemoryCache, redisConnectionString);
+        }
+
+        /// <summary>
+        /// Configures a RooHttpClient and creates named HttpClients for every clientList item with the accompanying base URL.
+        /// </summary>
+        /// <param name="services"></param>
+        /// <param name="channelId">Channel Id of application.</param>
+        /// <param name="httpClients">List of HttpClient names (as enums) and base URLs to configure.</param>
+        /// <param name="useMemoryCache">Whether to use memory cache when storing tokens. Redis takes precedence if Redis connection string is passed in.</param>
+        /// <param name="redisConnectionString">Connection string to Redis, controls whether to use Redis when storing tokens. Takes precedence over memory cache.</param>
+        /// <param name=""></param>
+        /// <returns></returns>
+        public static IServiceCollection RooHttpClientConfig(this IServiceCollection services, string channelId, List<(Enum Name, string BaseUrl)> httpClients, bool useMemoryCache = false, string? redisConnectionString = null)
+        {
+            //Iterate through client list and create named client for each item
+            foreach (var httpClient in httpClients)
+            {
+                if (string.IsNullOrEmpty(httpClient.Name.ToString()) || string.IsNullOrEmpty(httpClient.BaseUrl))
+                {
+                    continue;
+                }
+                services.AddHttpClient(httpClient.Name.ToString(), config =>
+                {
+                    config.BaseAddress = new Uri(httpClient.BaseUrl);
+                }).AddHttpMessageHandler<HeaderPropagateMiddleware>();
+            }
+            return CreateHttpClient(services, channelId, useMemoryCache, redisConnectionString);
+        }
+
+        private static IServiceCollection CreateHttpClient(IServiceCollection services, string channelId, bool useMemoryCache = false, string? redisConnectionString = null)
+        {
+            //Add Azure Active Directory authentication service
+            services.TryAddSingleton<IAzureAdClientAssertion, AzureAdClientAssertion>();
+
+            //Create RooHttpClient
+            if (!string.IsNullOrEmpty(redisConnectionString))
+            {
+                services.AddScoped<IRooHttpClient>(x =>
+                {
+                    var httpContextAccessor = x.GetRequiredService<IHttpContextAccessor>();
+                    var httpClientFactory = x.GetRequiredService<IHttpClientFactory>();
+                    var logger = x.GetRequiredService<IRooLogger>();
+                    var azureAdClientAssertion = x.GetRequiredService<IAzureAdClientAssertion>();
+                    var redisService = x.GetRequiredService<IRedisService>();
+                    return new RooHttpClient(channelId, httpContextAccessor, httpClientFactory, logger, azureAdClientAssertion, redisService);
+                });
+            }
+            else if (useMemoryCache)
+            {
+                services.AddScoped<IRooHttpClient>(x =>
+                {
+                    var httpContextAccessor = x.GetRequiredService<IHttpContextAccessor>();
+                    var httpClientFactory = x.GetRequiredService<IHttpClientFactory>();
+                    var logger = x.GetRequiredService<IRooLogger>();
+                    var azureAdClientAssertion = x.GetRequiredService<IAzureAdClientAssertion>();
+                    var cache = x.GetRequiredService<IMemoryCache>();
+                    return new RooHttpClient(channelId, httpContextAccessor, httpClientFactory, logger, azureAdClientAssertion, cache);
+                });
+            }
+            else
+            {
+                services.AddScoped<IRooHttpClient>(x =>
+                {
+                    var httpContextAccessor = x.GetRequiredService<IHttpContextAccessor>();
+                    var httpClientFactory = x.GetRequiredService<IHttpClientFactory>();
+                    var logger = x.GetRequiredService<IRooLogger>();
+                    var azureAdClientAssertion = x.GetRequiredService<IAzureAdClientAssertion>();
+                    return new RooHttpClient(channelId, httpContextAccessor, httpClientFactory, logger, azureAdClientAssertion);
+                });
+            }
+            return services;
+        }
+    }
+}

--- a/Roo.Azure.Configuration.Common/Logging/RooLogger.cs
+++ b/Roo.Azure.Configuration.Common/Logging/RooLogger.cs
@@ -23,7 +23,7 @@ namespace Roo.Azure.Configuration.Common.Logging
         /// <param name="context">HttpContext</param>
         /// <param name="message">Log message</param>
         /// <param name="e">Exception</param>
-        public void LogInformation(HttpContext context, string? message = null, Exception? ex = null);
+        public void LogInformation(HttpContext? context = null, string? message = null, Exception? ex = null);
 
         /// <summary>
         /// Create formatted log at the error level.
@@ -31,7 +31,7 @@ namespace Roo.Azure.Configuration.Common.Logging
         /// <param name="context">HttpContext</param>
         /// <param name="message">Log message</param>
         /// <param name="e">Exception</param>
-        public void LogError(HttpContext context, string? message = null, Exception? ex = null);
+        public void LogError(HttpContext? context = null, string? message = null, Exception? ex = null);
 
         /// <summary>
         /// Create formatted log at the warning level.
@@ -39,7 +39,7 @@ namespace Roo.Azure.Configuration.Common.Logging
         /// <param name="context">HttpContext</param>
         /// <param name="message">Log message</param>
         /// <param name="e">Exception</param>
-        public void LogWarning(HttpContext context, string? message = null, Exception? ex = null);
+        public void LogWarning(HttpContext? context = null, string? message = null, Exception? ex = null);
 
         /// <summary>
         /// Create formatted log at the trace level.
@@ -47,7 +47,7 @@ namespace Roo.Azure.Configuration.Common.Logging
         /// <param name="context">HttpContext</param>
         /// <param name="message">Log message</param>
         /// <param name="e">Exception</param>
-        public void LogTrace(HttpContext context, string? message = null, Exception? ex = null);
+        public void LogTrace(HttpContext? context = null, string? message = null, Exception? ex = null);
 
         /// <summary>
         /// Create formatted log at the critical level.
@@ -55,7 +55,7 @@ namespace Roo.Azure.Configuration.Common.Logging
         /// <param name="context">HttpContext</param>
         /// <param name="message">Log message</param>
         /// <param name="e">Exception</param>
-        public void LogCritical(HttpContext context, string? message = null, Exception? ex = null);
+        public void LogCritical(HttpContext? context = null, string? message = null, Exception? ex = null);
 
         /// <summary>
         /// Create formatted log at the debug level.
@@ -63,7 +63,7 @@ namespace Roo.Azure.Configuration.Common.Logging
         /// <param name="context">HttpContext</param>
         /// <param name="message">Log message</param>
         /// <param name="e">Exception</param>
-        public void LogDebug(HttpContext context, string? message = null, Exception? ex = null);
+        public void LogDebug(HttpContext? context = null, string? message = null, Exception? ex = null);
     }
 
     /// <summary>
@@ -74,10 +74,11 @@ namespace Roo.Azure.Configuration.Common.Logging
     /// </remarks>
     /// <param name="logger"></param>
     /// <param name="headerService"></param>
-    public partial class RooLogger(ILogger<RooLogger> logger, IHeaderService headerService) : IRooLogger
+    public partial class RooLogger(ILogger<RooLogger> logger, IHeaderService headerService, IHttpContextAccessor httpContextAccessor) : IRooLogger
     {
         private readonly ILogger<RooLogger> _logger = logger;
         private readonly IHeaderService _headerService = headerService;
+        private readonly IHttpContextAccessor _httpContextAccessor = httpContextAccessor;
 
         private const string encodePattern = @"\s+";
 
@@ -87,26 +88,35 @@ namespace Roo.Azure.Configuration.Common.Logging
         /// <param name="context">HttpContext</param>
         /// <param name="message">Log message</param>
         /// <param name="ex">Exception</param>
-        public void LogInformation(HttpContext context, string? message = null, Exception? ex = null)
+        public void LogInformation(HttpContext? context = null, string? message = null, Exception? ex = null)
         {
-            if (_headerService.DoesUserInfoHaveInfo(context.Request.Headers) && !string.IsNullOrEmpty(message))
+            if (context == null)
+            {
+                context = _httpContextAccessor.HttpContext;
+            }
+            if (context == null)
+            {
+                return;
+            }
+
+            if (_headerService.DoesUserInfoHaveInfo(context?.Request.Headers) && !string.IsNullOrEmpty(message))
             {
                 _logger.LogInformation(ex, "{SessionIdHeaderName}: {GetSessionId}, {TransactionIdHeaderName}: {GetTransactionId}, {ChannelIdHeaderName}: {GetChannelId}, {UserInfoHeaderName}: {GetUserInfo}, message: {message}",
-                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context.Request.Headers), Constants.ChannelIdHeaderName,
-                    _headerService.GetChannelId(context.Request.Headers), Constants.UserInfoHeaderName, JsonConvert.SerializeObject(_headerService.GetUserInfo(context.Request.Headers)), HttpUtility.HtmlEncode(EncodeLogRegex().Replace(message ?? "", " ")));
-            } else if (_headerService.DoesUserInfoHaveInfo(context.Request.Headers)) {
+                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context?.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context?.Request.Headers), Constants.ChannelIdHeaderName,
+                    _headerService.GetChannelId(context?.Request.Headers), Constants.UserInfoHeaderName, JsonConvert.SerializeObject(_headerService.GetUserInfo(context?.Request.Headers)), HttpUtility.HtmlEncode(EncodeLogRegex().Replace(message ?? "", " ")));
+            } else if (_headerService.DoesUserInfoHaveInfo(context?.Request.Headers)) {
                 _logger.LogInformation(ex, "{SessionIdHeaderName}: {GetSessionId}, {TransactionIdHeaderName}: {GetTransactionId}, {ChannelIdHeaderName}: {GetChannelId}, {UserInfoHeaderName}: {GetUserInfo}",
-                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context.Request.Headers), Constants.ChannelIdHeaderName,
-                    _headerService.GetChannelId(context.Request.Headers), Constants.UserInfoHeaderName, JsonConvert.SerializeObject(_headerService.GetUserInfo(context.Request.Headers)));
+                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context?.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context?.Request.Headers), Constants.ChannelIdHeaderName,
+                    _headerService.GetChannelId(context?.Request.Headers), Constants.UserInfoHeaderName, JsonConvert.SerializeObject(_headerService.GetUserInfo(context?.Request.Headers)));
             } else if (!string.IsNullOrEmpty(message)) {
                 _logger.LogInformation(ex, "{SessionIdHeaderName}: {GetSessionId}, {TransactionIdHeaderName}: {GetTransactionId}, {ChannelIdHeaderName}: {GetChannelId}, message: {message}",
-                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context.Request.Headers), Constants.ChannelIdHeaderName,
-                    _headerService.GetChannelId(context.Request.Headers), HttpUtility.HtmlEncode(EncodeLogRegex().Replace(message ?? "", " ")));
+                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context?.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context?.Request.Headers), Constants.ChannelIdHeaderName,
+                    _headerService.GetChannelId(context?.Request.Headers), HttpUtility.HtmlEncode(EncodeLogRegex().Replace(message ?? "", " ")));
             } else
             {
                 _logger.LogInformation(ex, "{SessionIdHeaderName}: {GetSessionId}, {TransactionIdHeaderName}: {GetTransactionId}, {ChannelIdHeaderName}: {GetChannelId}",
-                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context.Request.Headers), Constants.ChannelIdHeaderName,
-                    _headerService.GetChannelId(context.Request.Headers));
+                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context?.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context?.Request.Headers), Constants.ChannelIdHeaderName,
+                    _headerService.GetChannelId(context?.Request.Headers));
             }
         }
 
@@ -116,31 +126,40 @@ namespace Roo.Azure.Configuration.Common.Logging
         /// <param name="context">HttpContext</param>
         /// <param name="message">Log message</param>
         /// <param name="ex">Exception</param>
-        public void LogError(HttpContext context, string? message = null, Exception? ex = null)
+        public void LogError(HttpContext? context = null, string? message = null, Exception? ex = null)
         {
-            if (_headerService.DoesUserInfoHaveInfo(context.Request.Headers) && !string.IsNullOrEmpty(message))
+            if (context == null)
+            {
+                context = _httpContextAccessor.HttpContext;
+            }
+            if (context == null)
+            {
+                return;
+            }
+
+            if (_headerService.DoesUserInfoHaveInfo(context?.Request.Headers) && !string.IsNullOrEmpty(message))
             {
                 _logger.LogError(ex, "{SessionIdHeaderName}: {GetSessionId}, {TransactionIdHeaderName}: {GetTransactionId}, {ChannelIdHeaderName}: {GetChannelId}, {UserInfoHeaderName}: {GetUserInfo}, message: {message}",
-                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context.Request.Headers), Constants.ChannelIdHeaderName,
-                    _headerService.GetChannelId(context.Request.Headers), Constants.UserInfoHeaderName, JsonConvert.SerializeObject(_headerService.GetUserInfo(context.Request.Headers)), HttpUtility.HtmlEncode(EncodeLogRegex().Replace(message ?? "", " ")));
+                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context?.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context?.Request.Headers), Constants.ChannelIdHeaderName,
+                    _headerService.GetChannelId(context?.Request.Headers), Constants.UserInfoHeaderName, JsonConvert.SerializeObject(_headerService.GetUserInfo(context?.Request.Headers)), HttpUtility.HtmlEncode(EncodeLogRegex().Replace(message ?? "", " ")));
             }
-            else if (_headerService.DoesUserInfoHaveInfo(context.Request.Headers))
+            else if (_headerService.DoesUserInfoHaveInfo(context?.Request.Headers))
             {
                 _logger.LogError(ex, "{SessionIdHeaderName}: {GetSessionId}, {TransactionIdHeaderName}: {GetTransactionId}, {ChannelIdHeaderName}: {GetChannelId}, {UserInfoHeaderName}: {GetUserInfo}",
-                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context.Request.Headers), Constants.ChannelIdHeaderName,
-                    _headerService.GetChannelId(context.Request.Headers), Constants.UserInfoHeaderName, JsonConvert.SerializeObject(_headerService.GetUserInfo(context.Request.Headers)));
+                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context?.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context?.Request.Headers), Constants.ChannelIdHeaderName,
+                    _headerService.GetChannelId(context?.Request.Headers), Constants.UserInfoHeaderName, JsonConvert.SerializeObject(_headerService.GetUserInfo(context?.Request.Headers)));
             }
             else if (!string.IsNullOrEmpty(message))
             {
                 _logger.LogError(ex, "{SessionIdHeaderName}: {GetSessionId}, {TransactionIdHeaderName}: {GetTransactionId}, {ChannelIdHeaderName}: {GetChannelId}, message: {message}",
-                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context.Request.Headers), Constants.ChannelIdHeaderName,
-                    _headerService.GetChannelId(context.Request.Headers), HttpUtility.HtmlEncode(EncodeLogRegex().Replace(message ?? "", " ")));
+                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context?.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context?.Request.Headers), Constants.ChannelIdHeaderName,
+                    _headerService.GetChannelId(context?.Request.Headers), HttpUtility.HtmlEncode(EncodeLogRegex().Replace(message ?? "", " ")));
             }
             else
             {
                 _logger.LogError(ex, "{SessionIdHeaderName}: {GetSessionId}, {TransactionIdHeaderName}: {GetTransactionId}, {ChannelIdHeaderName}: {GetChannelId}",
-                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context.Request.Headers), Constants.ChannelIdHeaderName,
-                    _headerService.GetChannelId(context.Request.Headers));
+                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context?.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context?.Request.Headers), Constants.ChannelIdHeaderName,
+                    _headerService.GetChannelId(context?.Request.Headers));
             }
         }
 
@@ -150,31 +169,40 @@ namespace Roo.Azure.Configuration.Common.Logging
         /// <param name="context">HttpContext</param>
         /// <param name="message">Log message</param>
         /// <param name="e">Exception</param>
-        public void LogWarning(HttpContext context, string? message = null, Exception? ex = null)
+        public void LogWarning(HttpContext? context = null, string? message = null, Exception? ex = null)
         {
-            if (_headerService.DoesUserInfoHaveInfo(context.Request.Headers) && !string.IsNullOrEmpty(message))
+            if (context == null)
+            {
+                context = _httpContextAccessor.HttpContext;
+            }
+            if (context == null)
+            {
+                return;
+            }
+
+            if (_headerService.DoesUserInfoHaveInfo(context?.Request.Headers) && !string.IsNullOrEmpty(message))
             {
                 _logger.LogWarning(ex, "{SessionIdHeaderName}: {GetSessionId}, {TransactionIdHeaderName}: {GetTransactionId}, {ChannelIdHeaderName}: {GetChannelId}, {UserInfoHeaderName}: {GetUserInfo}, message: {message}",
-                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context.Request.Headers), Constants.ChannelIdHeaderName,
-                    _headerService.GetChannelId(context.Request.Headers), Constants.UserInfoHeaderName, JsonConvert.SerializeObject(_headerService.GetUserInfo(context.Request.Headers)), HttpUtility.HtmlEncode(EncodeLogRegex().Replace(message ?? "", " ")));
+                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context?.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context?.Request.Headers), Constants.ChannelIdHeaderName,
+                    _headerService.GetChannelId(context?.Request.Headers), Constants.UserInfoHeaderName, JsonConvert.SerializeObject(_headerService.GetUserInfo(context?.Request.Headers)), HttpUtility.HtmlEncode(EncodeLogRegex().Replace(message ?? "", " ")));
             }
-            else if (_headerService.DoesUserInfoHaveInfo(context.Request.Headers))
+            else if (_headerService.DoesUserInfoHaveInfo(context?.Request.Headers))
             {
                 _logger.LogWarning(ex, "{SessionIdHeaderName}: {GetSessionId}, {TransactionIdHeaderName}: {GetTransactionId}, {ChannelIdHeaderName}: {GetChannelId}, {UserInfoHeaderName}: {GetUserInfo}",
-                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context.Request.Headers), Constants.ChannelIdHeaderName,
-                    _headerService.GetChannelId(context.Request.Headers), Constants.UserInfoHeaderName, JsonConvert.SerializeObject(_headerService.GetUserInfo(context.Request.Headers)));
+                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context?.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context?.Request.Headers), Constants.ChannelIdHeaderName,
+                    _headerService.GetChannelId(context?.Request.Headers), Constants.UserInfoHeaderName, JsonConvert.SerializeObject(_headerService.GetUserInfo(context?.Request.Headers)));
             }
             else if (!string.IsNullOrEmpty(message))
             {
                 _logger.LogWarning(ex, "{SessionIdHeaderName}: {GetSessionId}, {TransactionIdHeaderName}: {GetTransactionId}, {ChannelIdHeaderName}: {GetChannelId}, message: {message}",
-                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context.Request.Headers), Constants.ChannelIdHeaderName,
-                    _headerService.GetChannelId(context.Request.Headers), HttpUtility.HtmlEncode(EncodeLogRegex().Replace(message ?? "", " ")));
+                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context?.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context?.Request.Headers), Constants.ChannelIdHeaderName,
+                    _headerService.GetChannelId(context?.Request.Headers), HttpUtility.HtmlEncode(EncodeLogRegex().Replace(message ?? "", " ")));
             }
             else
             {
                 _logger.LogWarning(ex, "{SessionIdHeaderName}: {GetSessionId}, {TransactionIdHeaderName}: {GetTransactionId}, {ChannelIdHeaderName}: {GetChannelId}",
-                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context.Request.Headers), Constants.ChannelIdHeaderName,
-                    _headerService.GetChannelId(context.Request.Headers));
+                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context?.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context?.Request.Headers), Constants.ChannelIdHeaderName,
+                    _headerService.GetChannelId(context?.Request.Headers));
             }
         }
 
@@ -184,31 +212,40 @@ namespace Roo.Azure.Configuration.Common.Logging
         /// <param name="context">HttpContext</param>
         /// <param name="message">Log message</param>
         /// <param name="e">Exception</param>
-        public void LogTrace(HttpContext context, string? message = null, Exception? ex = null)
+        public void LogTrace(HttpContext? context = null, string? message = null, Exception? ex = null)
         {
-            if (_headerService.DoesUserInfoHaveInfo(context.Request.Headers) && !string.IsNullOrEmpty(message))
+            if (context == null)
+            {
+                context = _httpContextAccessor.HttpContext;
+            }
+            if (context == null)
+            {
+                return;
+            }
+
+            if (_headerService.DoesUserInfoHaveInfo(context?.Request.Headers) && !string.IsNullOrEmpty(message))
             {
                 _logger.LogTrace(ex, "{SessionIdHeaderName}: {GetSessionId}, {TransactionIdHeaderName}: {GetTransactionId}, {ChannelIdHeaderName}: {GetChannelId}, {UserInfoHeaderName}: {GetUserInfo}, message: {message}",
-                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context.Request.Headers), Constants.ChannelIdHeaderName,
-                    _headerService.GetChannelId(context.Request.Headers), Constants.UserInfoHeaderName, JsonConvert.SerializeObject(_headerService.GetUserInfo(context.Request.Headers)), HttpUtility.HtmlEncode(EncodeLogRegex().Replace(message ?? "", " ")));
+                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context?.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context?.Request.Headers), Constants.ChannelIdHeaderName,
+                    _headerService.GetChannelId(context?.Request.Headers), Constants.UserInfoHeaderName, JsonConvert.SerializeObject(_headerService.GetUserInfo(context?.Request.Headers)), HttpUtility.HtmlEncode(EncodeLogRegex().Replace(message ?? "", " ")));
             }
-            else if (_headerService.DoesUserInfoHaveInfo(context.Request.Headers))
+            else if (_headerService.DoesUserInfoHaveInfo(context?.Request.Headers))
             {
                 _logger.LogTrace(ex, "{SessionIdHeaderName}: {GetSessionId}, {TransactionIdHeaderName}: {GetTransactionId}, {ChannelIdHeaderName}: {GetChannelId}, {UserInfoHeaderName}: {GetUserInfo}",
-                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context.Request.Headers), Constants.ChannelIdHeaderName,
-                    _headerService.GetChannelId(context.Request.Headers), Constants.UserInfoHeaderName, JsonConvert.SerializeObject(_headerService.GetUserInfo(context.Request.Headers)));
+                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context?.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context?.Request.Headers), Constants.ChannelIdHeaderName,
+                    _headerService.GetChannelId(context?.Request.Headers), Constants.UserInfoHeaderName, JsonConvert.SerializeObject(_headerService.GetUserInfo(context?.Request.Headers)));
             }
             else if (!string.IsNullOrEmpty(message))
             {
                 _logger.LogTrace(ex, "{SessionIdHeaderName}: {GetSessionId}, {TransactionIdHeaderName}: {GetTransactionId}, {ChannelIdHeaderName}: {GetChannelId}, message: {message}",
-                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context.Request.Headers), Constants.ChannelIdHeaderName,
-                    _headerService.GetChannelId(context.Request.Headers), HttpUtility.HtmlEncode(EncodeLogRegex().Replace(message ?? "", " ")));
+                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context?.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context?.Request.Headers), Constants.ChannelIdHeaderName,
+                    _headerService.GetChannelId(context?.Request.Headers), HttpUtility.HtmlEncode(EncodeLogRegex().Replace(message ?? "", " ")));
             }
             else
             {
                 _logger.LogTrace(ex, "{SessionIdHeaderName}: {GetSessionId}, {TransactionIdHeaderName}: {GetTransactionId}, {ChannelIdHeaderName}: {GetChannelId}",
-                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context.Request.Headers), Constants.ChannelIdHeaderName,
-                    _headerService.GetChannelId(context.Request.Headers));
+                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context?.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context?.Request.Headers), Constants.ChannelIdHeaderName,
+                    _headerService.GetChannelId(context?.Request.Headers));
             }
         }
 
@@ -218,31 +255,40 @@ namespace Roo.Azure.Configuration.Common.Logging
         /// <param name="context">HttpContext</param>
         /// <param name="message">Log message</param>
         /// <param name="e">Exception</param>
-        public void LogCritical(HttpContext context, string? message = null, Exception? ex = null)
+        public void LogCritical(HttpContext? context = null, string? message = null, Exception? ex = null)
         {
-            if (_headerService.DoesUserInfoHaveInfo(context.Request.Headers) && !string.IsNullOrEmpty(message))
+            if (context == null)
+            {
+                context = _httpContextAccessor.HttpContext;
+            }
+            if (context == null)
+            {
+                return;
+            }
+
+            if (_headerService.DoesUserInfoHaveInfo(context?.Request.Headers) && !string.IsNullOrEmpty(message))
             {
                 _logger.LogCritical(ex, "{SessionIdHeaderName}: {GetSessionId}, {TransactionIdHeaderName}: {GetTransactionId}, {ChannelIdHeaderName}: {GetChannelId}, {UserInfoHeaderName}: {GetUserInfo}, message: {message}",
-                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context.Request.Headers), Constants.ChannelIdHeaderName,
-                    _headerService.GetChannelId(context.Request.Headers), Constants.UserInfoHeaderName, JsonConvert.SerializeObject(_headerService.GetUserInfo(context.Request.Headers)), HttpUtility.HtmlEncode(EncodeLogRegex().Replace(message ?? "", " ")));
+                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context?.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context?.Request.Headers), Constants.ChannelIdHeaderName,
+                    _headerService.GetChannelId(context?.Request.Headers), Constants.UserInfoHeaderName, JsonConvert.SerializeObject(_headerService.GetUserInfo(context?.Request.Headers)), HttpUtility.HtmlEncode(EncodeLogRegex().Replace(message ?? "", " ")));
             }
-            else if (_headerService.DoesUserInfoHaveInfo(context.Request.Headers))
+            else if (_headerService.DoesUserInfoHaveInfo(context?.Request.Headers))
             {
                 _logger.LogCritical(ex, "{SessionIdHeaderName}: {GetSessionId}, {TransactionIdHeaderName}: {GetTransactionId}, {ChannelIdHeaderName}: {GetChannelId}, {UserInfoHeaderName}: {GetUserInfo}",
-                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context.Request.Headers), Constants.ChannelIdHeaderName,
-                    _headerService.GetChannelId(context.Request.Headers), Constants.UserInfoHeaderName, JsonConvert.SerializeObject(_headerService.GetUserInfo(context.Request.Headers)));
+                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context?.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context?.Request.Headers), Constants.ChannelIdHeaderName,
+                    _headerService.GetChannelId(context?.Request.Headers), Constants.UserInfoHeaderName, JsonConvert.SerializeObject(_headerService.GetUserInfo(context?.Request.Headers)));
             }
             else if (!string.IsNullOrEmpty(message))
             {
                 _logger.LogCritical(ex, "{SessionIdHeaderName}: {GetSessionId}, {TransactionIdHeaderName}: {GetTransactionId}, {ChannelIdHeaderName}: {GetChannelId}, message: {message}",
-                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context.Request.Headers), Constants.ChannelIdHeaderName,
-                    _headerService.GetChannelId(context.Request.Headers), HttpUtility.HtmlEncode(EncodeLogRegex().Replace(message ?? "", " ")));
+                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context?.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context?.Request.Headers), Constants.ChannelIdHeaderName,
+                    _headerService.GetChannelId(context?.Request.Headers), HttpUtility.HtmlEncode(EncodeLogRegex().Replace(message ?? "", " ")));
             }
             else
             {
                 _logger.LogCritical(ex, "{SessionIdHeaderName}: {GetSessionId}, {TransactionIdHeaderName}: {GetTransactionId}, {ChannelIdHeaderName}: {GetChannelId}",
-                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context.Request.Headers), Constants.ChannelIdHeaderName,
-                    _headerService.GetChannelId(context.Request.Headers));
+                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context?.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context?.Request.Headers), Constants.ChannelIdHeaderName,
+                    _headerService.GetChannelId(context?.Request.Headers));
             }
         }
 
@@ -252,31 +298,40 @@ namespace Roo.Azure.Configuration.Common.Logging
         /// <param name="context">HttpContext</param>
         /// <param name="message">Log message</param>
         /// <param name="e">Exception</param>
-        public void LogDebug(HttpContext context, string? message = null, Exception? ex = null)
+        public void LogDebug(HttpContext? context = null, string? message = null, Exception? ex = null)
         {
-            if (_headerService.DoesUserInfoHaveInfo(context.Request.Headers) && !string.IsNullOrEmpty(message))
+            if (context == null)
+            {
+                context = _httpContextAccessor.HttpContext;
+            }
+            if (context == null)
+            {
+                return;
+            }
+
+            if (_headerService.DoesUserInfoHaveInfo(context?.Request.Headers) && !string.IsNullOrEmpty(message))
             {
                 _logger.LogDebug(ex, "{SessionIdHeaderName}: {GetSessionId}, {TransactionIdHeaderName}: {GetTransactionId}, {ChannelIdHeaderName}: {GetChannelId}, {UserInfoHeaderName}: {GetUserInfo}, message: {message}",
-                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context.Request.Headers), Constants.ChannelIdHeaderName,
-                    _headerService.GetChannelId(context.Request.Headers), Constants.UserInfoHeaderName, JsonConvert.SerializeObject(_headerService.GetUserInfo(context.Request.Headers)), HttpUtility.HtmlEncode(EncodeLogRegex().Replace(message ?? "", " ")));
+                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context?.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context?.Request.Headers), Constants.ChannelIdHeaderName,
+                    _headerService.GetChannelId(context?.Request.Headers), Constants.UserInfoHeaderName, JsonConvert.SerializeObject(_headerService.GetUserInfo(context?.Request.Headers)), HttpUtility.HtmlEncode(EncodeLogRegex().Replace(message ?? "", " ")));
             }
-            else if (_headerService.DoesUserInfoHaveInfo(context.Request.Headers))
+            else if (_headerService.DoesUserInfoHaveInfo(context?.Request.Headers))
             {
                 _logger.LogDebug(ex, "{SessionIdHeaderName}: {GetSessionId}, {TransactionIdHeaderName}: {GetTransactionId}, {ChannelIdHeaderName}: {GetChannelId}, {UserInfoHeaderName}: {GetUserInfo}",
-                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context.Request.Headers), Constants.ChannelIdHeaderName,
-                    _headerService.GetChannelId(context.Request.Headers), Constants.UserInfoHeaderName, JsonConvert.SerializeObject(_headerService.GetUserInfo(context.Request.Headers)));
+                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context?.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context?.Request.Headers), Constants.ChannelIdHeaderName,
+                    _headerService.GetChannelId(context?.Request.Headers), Constants.UserInfoHeaderName, JsonConvert.SerializeObject(_headerService.GetUserInfo(context?.Request.Headers)));
             }
             else if (!string.IsNullOrEmpty(message))
             {
                 _logger.LogDebug(ex, "{SessionIdHeaderName}: {GetSessionId}, {TransactionIdHeaderName}: {GetTransactionId}, {ChannelIdHeaderName}: {GetChannelId}, message: {message}",
-                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context.Request.Headers), Constants.ChannelIdHeaderName,
-                    _headerService.GetChannelId(context.Request.Headers), HttpUtility.HtmlEncode(EncodeLogRegex().Replace(message ?? "", " ")));
+                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context?.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context?.Request.Headers), Constants.ChannelIdHeaderName,
+                    _headerService.GetChannelId(context?.Request.Headers), HttpUtility.HtmlEncode(EncodeLogRegex().Replace(message ?? "", " ")));
             }
             else
             {
                 _logger.LogDebug(ex, "{SessionIdHeaderName}: {GetSessionId}, {TransactionIdHeaderName}: {GetTransactionId}, {ChannelIdHeaderName}: {GetChannelId}",
-                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context.Request.Headers), Constants.ChannelIdHeaderName,
-                    _headerService.GetChannelId(context.Request.Headers));
+                    Constants.SessionIdHeaderName, _headerService.GetSessionId(context?.Request.Headers), Constants.TransactionIdHeaderName, _headerService.GetTransactionId(context?.Request.Headers), Constants.ChannelIdHeaderName,
+                    _headerService.GetChannelId(context?.Request.Headers));
             }
         }
 

--- a/Roo.Azure.Configuration.Common/Logging/RooTelemetryLogger.cs
+++ b/Roo.Azure.Configuration.Common/Logging/RooTelemetryLogger.cs
@@ -3,11 +3,6 @@ using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Metrics;
 using Roo.Azure.Configuration.Common.Models;
-using static IdentityModel.OidcConstants;
-using System.Security.Policy;
-using static System.Runtime.InteropServices.JavaScript.JSType;
-using System;
-using Microsoft.ApplicationInsights.Channel;
 
 namespace Roo.Azure.Configuration.Common.Logging
 {
@@ -444,7 +439,7 @@ namespace Roo.Azure.Configuration.Common.Logging
         /// <returns></returns>
         public async Task<bool> TelemetryFlushAsync(CancellationToken? token)
         {
-            return await _telemetryClient.FlushAsync(token ?? new CancellationToken());
+            return await _telemetryClient.FlushAsync(token ?? new CancellationToken()).ConfigureAwait(false);
         }
     }
 }

--- a/Roo.Azure.Configuration.Common/Middlewares/HeaderPropagateMiddleware.cs
+++ b/Roo.Azure.Configuration.Common/Middlewares/HeaderPropagateMiddleware.cs
@@ -53,7 +53,7 @@ namespace Roo.Azure.Configuration.Common.Middlewares
             {
                 var userInfo = new UserInfo()
                 {
-                    Username = HttpContextAccessor.HttpContext.User.FindFirstValue(Constants.UserInfoUsername) ?? "",
+                    LoginId = HttpContextAccessor.HttpContext.User.FindFirstValue(Constants.UserInfoUsername) ?? "",
                     Email = HttpContextAccessor.HttpContext.User.FindFirstValue(ClaimTypes.Email) ?? "",
                     UserId = HttpContextAccessor.HttpContext.User.FindFirstValue("UserId") ?? "",
                     IsAuthenticated = HttpContextAccessor.HttpContext.User.Identity?.IsAuthenticated ?? false

--- a/Roo.Azure.Configuration.Common/Models/UserInfo.cs
+++ b/Roo.Azure.Configuration.Common/Models/UserInfo.cs
@@ -3,9 +3,9 @@
     public class UserInfo
     {
         /// <summary>
-        /// Gets/Sets the username for the current user using.
+        /// Gets/Sets the login id for the current user using.
         /// </summary>
-        public string? Username { get; set; }
+        public string? LoginId { get; set; }
 
         /// <summary>
         /// Gets/Sets the email attached to the current user.
@@ -18,6 +18,11 @@
         public string? UserId { get; set; }
 
         /// <summary>
+        /// Sub id user has assigned
+        /// </summary>
+        public string? SubId { get; set; }
+
+        /// <summary>
         /// Gets/Sets whether the user is authenticated.
         /// </summary>
         public bool IsAuthenticated { get; set; } = false;
@@ -27,7 +32,7 @@
         /// </summary>
         public bool HasInfo
         {
-            get => !string.IsNullOrEmpty(Username) || !string.IsNullOrEmpty(Email) || !string.IsNullOrEmpty(UserId);
+            get => !string.IsNullOrEmpty(LoginId) || !string.IsNullOrEmpty(Email) || !string.IsNullOrEmpty(UserId);
         }
     }
 }

--- a/Roo.Azure.Configuration.Common/Roo.Azure.Configuration.Common.csproj
+++ b/Roo.Azure.Configuration.Common/Roo.Azure.Configuration.Common.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="7.0.1" />

--- a/Roo.Azure.Configuration.Common/ServiceExceptions/ServiceExceptionConverter.cs
+++ b/Roo.Azure.Configuration.Common/ServiceExceptions/ServiceExceptionConverter.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
 using System.ComponentModel.DataAnnotations;
 
 namespace Roo.Azure.Configuration.Common.ServiceExceptions
@@ -228,7 +229,13 @@ namespace Roo.Azure.Configuration.Common.ServiceExceptions
                 ErrorCode.UnauthorizedAccess => new UnauthorizedAccessException(ex.Message, ex.InnerException),
                 ErrorCode.ValidationFailure => ex.Error.Details != null && ex.Error.Details.TryGetValue("Value", out string? value) && ex.Error.Details.TryGetValue("ResultMemberNames", out string? resultMemberNames) ?
                     new ValidationException(new ValidationResult(ex.Message, resultMemberNames.Split(", ").ToList()), null, value) : ex.Error.Details != null && ex.Error.Details.TryGetValue("Value", out string? valueNoMember) ? new ValidationException(ex.Message, null, valueNoMember) : new ValidationException(ex.Message, ex.InnerException),
-                ErrorCode.None => new Exception(ex.Message, ex.InnerException)
+                ErrorCode.None => new Exception(ex.Message, ex.InnerException),
+                ErrorCode.BadRequest => new BadHttpRequestException(ex.Message, ex.InnerException ?? new()),
+                ErrorCode.SessionIdHeaderNotFound => new Exception("Session Id header (session-id) is missing from the headers.", ex.InnerException),
+                ErrorCode.TransactionIdHeaderNotFound => new Exception("Transaction Id header (transaction-id) is missing from the headers.", ex.InnerException),
+                ErrorCode.ChannelIdHeaderNotFound => new Exception("Channel Id header (channel-id) is missing from the headers.", ex.InnerException),
+                ErrorCode.UserInfoHeaderNotFound => new Exception("User Info header (user-info) is missing from the headers.", ex.InnerException),
+                _ => new Exception(ex.Message)
             };
         }
     }

--- a/Roo.Azure.Configuration.Common/Services/FeatureManagerService.cs
+++ b/Roo.Azure.Configuration.Common/Services/FeatureManagerService.cs
@@ -51,7 +51,7 @@ namespace Roo.Azure.Configuration.Common.Services
         /// <returns></returns>
         public async Task<bool> IsFeatureEnabled(string name)
         {
-            return await _featureManager.IsEnabledAsync(name);
+            return await _featureManager.IsEnabledAsync(name).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace Roo.Azure.Configuration.Common.Services
         /// <returns></returns>
         public async Task<bool> IsFeatureEnabled<T>(string name, T context)
         {
-            return await _featureManager.IsEnabledAsync(name, context);
+            return await _featureManager.IsEnabledAsync(name, context).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Roo.Azure.Configuration.Common/Services/HeaderService.cs
+++ b/Roo.Azure.Configuration.Common/Services/HeaderService.cs
@@ -57,7 +57,7 @@ namespace Roo.Azure.Configuration.Common.Services
         /// </summary>
         /// <param name="headers"></param>
         /// <returns>username value</returns>
-        public string? GetUserInfoUsername(IHeaderDictionary? headers);
+        public string? GetUserInfoLoginId(IHeaderDictionary? headers);
 
         /// <summary>
         /// Get user-info header
@@ -174,7 +174,7 @@ namespace Roo.Azure.Configuration.Common.Services
         /// </summary>
         /// <param name="headers"></param>
         /// <returns>username value</returns>
-        public string? GetUserInfoUsername(IHeaderDictionary? headers)
+        public string? GetUserInfoLoginId(IHeaderDictionary? headers)
         {
             if (headers != null)
             {
@@ -182,7 +182,7 @@ namespace Roo.Azure.Configuration.Common.Services
 
                 if (userInfo != null)
                 {
-                    return userInfo.Username;
+                    return userInfo.LoginId;
                 }
             }
 

--- a/Roo.Azure.Configuration.Common/Services/RedisService.cs
+++ b/Roo.Azure.Configuration.Common/Services/RedisService.cs
@@ -115,7 +115,7 @@ namespace Roo.Azure.Configuration.Common.Services
         /// <returns></returns>
         public async Task<string?> Get(string key)
         {
-            return await _redis.GetDatabase().StringGetAsync(key);
+            return await _redis.GetDatabase().StringGetAsync(key).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -125,7 +125,7 @@ namespace Roo.Azure.Configuration.Common.Services
         /// <returns></returns>
         public async Task<(string? token, TimeSpan? expirationTimeSpan)> GetWithExpiration(string key)
         {
-            var result = await _redis.GetDatabase().StringGetWithExpiryAsync(key);
+            var result = await _redis.GetDatabase().StringGetWithExpiryAsync(key).ConfigureAwait(false);
             return (result.Value, result.Expiry);
         }
 
@@ -136,7 +136,7 @@ namespace Roo.Azure.Configuration.Common.Services
         /// <returns></returns>
         public async Task<T?> GetObject<T>(string key)
         {
-            var result = await _redis.GetDatabase().HashGetAllAsync(key);
+            var result = await _redis.GetDatabase().HashGetAllAsync(key).ConfigureAwait(false);
             return HashEntryToObject<T>(result);
         }
 
@@ -148,7 +148,7 @@ namespace Roo.Azure.Configuration.Common.Services
         /// <returns></returns>
         public async Task<string?> GetField(string key, string field)
         {
-            return await _redis.GetDatabase().HashGetAsync(key, field);
+            return await _redis.GetDatabase().HashGetAsync(key, field).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -159,7 +159,7 @@ namespace Roo.Azure.Configuration.Common.Services
         /// <returns></returns>
         public async Task<bool> Set(string key, string value)
         {
-            return await _redis.GetDatabase().StringSetAsync(key, value, null);
+            return await _redis.GetDatabase().StringSetAsync(key, value, null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -171,7 +171,7 @@ namespace Roo.Azure.Configuration.Common.Services
         /// <returns></returns>
         public async Task<bool> Set(string key, string value, TimeSpan expiration)
         {
-            return await _redis.GetDatabase().StringSetAsync(key, value, expiration);
+            return await _redis.GetDatabase().StringSetAsync(key, value, expiration).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -187,7 +187,7 @@ namespace Roo.Azure.Configuration.Common.Services
                 return;
             }
             var result = ObjectToHashEntry(value);
-            await _redis.GetDatabase().HashSetAsync(key, result);
+            await _redis.GetDatabase().HashSetAsync(key, result).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -199,7 +199,7 @@ namespace Roo.Azure.Configuration.Common.Services
         /// <returns></returns>
         public async Task<bool> SetField(string key, string field, string value)
         {
-            return await _redis.GetDatabase().HashSetAsync(key, field, value);
+            return await _redis.GetDatabase().HashSetAsync(key, field, value).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -209,7 +209,7 @@ namespace Roo.Azure.Configuration.Common.Services
         /// <returns></returns>
         public async Task<bool> Delete(string key)
         {
-            return await _redis.GetDatabase().KeyDeleteAsync(key);
+            return await _redis.GetDatabase().KeyDeleteAsync(key).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -220,7 +220,7 @@ namespace Roo.Azure.Configuration.Common.Services
         /// <returns></returns>
         public async Task<bool> DeleteField(string key, string field)
         {
-            return await _redis.GetDatabase().HashDeleteAsync(key, field);
+            return await _redis.GetDatabase().HashDeleteAsync(key, field).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Roo.Azure.Configuration.Common/Services/ServiceBusService.cs
+++ b/Roo.Azure.Configuration.Common/Services/ServiceBusService.cs
@@ -1,0 +1,208 @@
+﻿using Azure.Core;
+using Azure.Messaging.ServiceBus;
+
+namespace Roo.Azure.Configuration.Common.Services
+{
+    /// <summary>
+    /// Wrapper for Azure Service Bus methods to simplify calls.
+    /// </summary>
+    public interface IServiceBusService
+    {
+        /// <summary>
+        /// Send string message to service bus using token authorization.
+        /// </summary>
+        /// <param name="serviceBusNamespace">Namespace of service bus.</param>
+        /// <param name="serviceBusQueueName">Queue name of service bus.</param>
+        /// <param name="message">Message being sent.</param>
+        /// <param name="token">Token with authorization to send messages with the service bus.</param>
+        /// <returns></returns>
+        public Task SendToServiceBus(string serviceBusNamespace, string serviceBusQueueName, string message, TokenCredential token);
+
+        /// <summary>
+        /// Send string message to service bus using connection string authorization.
+        /// </summary>
+        /// <param name="serviceBusConnectionString">Connection string of service bus.</param>
+        /// <param name="serviceBusQueueName">Queue name of service bus.</param>
+        /// <param name="message">Message being sent.</param>
+        /// <returns></returns>
+        public Task SendToServiceBus(string serviceBusConnectionString, string serviceBusQueueName, string message);
+
+        /// <summary>
+        /// Send byte message to service bus using token authorization.
+        /// </summary>
+        /// <param name="serviceBusNamespace">Namespace of service bus.</param>
+        /// <param name="serviceBusQueueName">Queue name of service bus.</param>
+        /// <param name="message">Message being sent.</param>
+        /// <param name="token">Token with authorization to send messages with the service bus.</param>
+        /// <returns></returns>
+        public Task SendToServiceBus(string serviceBusNamespace, string serviceBusQueueName, ReadOnlyMemory<byte> message, TokenCredential token);
+
+        /// <summary>
+        /// Send byte message to service bus using connection string authorization.
+        /// </summary>
+        /// <param name="serviceBusConnectionString">Connection string of service bus.</param>
+        /// <param name="serviceBusQueueName">Queue name of service bus.</param>
+        /// <param name="message">Message being sent.</param>
+        /// <returns></returns>
+        public Task SendToServiceBus(string serviceBusConnectionString, string serviceBusQueueName, ReadOnlyMemory<byte> message);
+
+        /// <summary>
+        /// Send binary data message to service bus using token authorization.
+        /// </summary>
+        /// <param name="serviceBusNamespace">Namespace of service bus.</param>
+        /// <param name="serviceBusQueueName">Queue name of service bus.</param>
+        /// <param name="message">Message being sent.</param>
+        /// <param name="token">Token with authorization to send messages with the service bus.</param>
+        /// <returns></returns>
+        public Task SendToServiceBus(string serviceBusNamespace, string serviceBusQueueName, BinaryData message, TokenCredential token);
+
+        /// <summary>
+        /// Send binary data message to service bus using connection string authorization.
+        /// </summary>
+        /// <param name="serviceBusConnectionString">Connection string of service bus.</param>
+        /// <param name="serviceBusQueueName">Queue name of service bus.</param>
+        /// <param name="message">Message being sent.</param>
+        /// <returns></returns>
+        public Task SendToServiceBus(string serviceBusConnectionString, string serviceBusQueueName, BinaryData message);
+
+        /// <summary>
+        /// Send <see cref="ServiceBusReceivedMessage"/> message to service bus using token authorization.
+        /// </summary>
+        /// <param name="serviceBusNamespace">Namespace of service bus.</param>
+        /// <param name="serviceBusQueueName">Queue name of service bus.</param>
+        /// <param name="message">Message being sent.</param>
+        /// <param name="token">Token with authorization to send messages with the service bus.</param>
+        /// <returns></returns>
+        public Task SendToServiceBus(string serviceBusNamespace, string serviceBusQueueName, ServiceBusReceivedMessage message, TokenCredential token);
+
+        /// <summary>
+        /// Send <see cref="ServiceBusReceivedMessage"/> message to service bus using connection string authorization.
+        /// </summary>
+        /// <param name="serviceBusConnectionString">Connection string of service bus.</param>
+        /// <param name="serviceBusQueueName">Queue name of service bus.</param>
+        /// <param name="message">Message being sent.</param>
+        /// <returns></returns>
+        public Task SendToServiceBus(string serviceBusConnectionString, string serviceBusQueueName, ServiceBusReceivedMessage message);
+    }
+
+    public class ServiceBusService : IServiceBusService
+    {
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <param name="serviceBusNamespace"></param>
+        /// <param name="serviceBusQueueName"></param>
+        /// <param name="message"></param>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
+        public async Task SendToServiceBus(string serviceBusNamespace, string serviceBusQueueName, string message, TokenCredential token)
+        {
+            var serviceBusClient = new ServiceBusClient($"{serviceBusNamespace}.servicebus.windows.net", token);
+            var serviceBusSender = serviceBusClient.CreateSender(serviceBusQueueName);
+            await serviceBusSender.SendMessageAsync(new ServiceBusMessage(message)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <param name="serviceBusConnectionString"></param>
+        /// <param name="serviceBusQueueName"></param>
+        /// <param name="message"></param>
+        /// <returns></returns>
+        public async Task SendToServiceBus(string serviceBusConnectionString, string serviceBusQueueName, string message)
+        {
+            var serviceBusClient = new ServiceBusClient(serviceBusConnectionString);
+            var serviceBusSender = serviceBusClient.CreateSender(serviceBusQueueName);
+            await serviceBusSender.SendMessageAsync(new ServiceBusMessage(message)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <param name="serviceBusNamespace"></param>
+        /// <param name="serviceBusQueueName"></param>
+        /// <param name="message"></param>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        public async Task SendToServiceBus(string serviceBusNamespace, string serviceBusQueueName, ReadOnlyMemory<byte> message, TokenCredential token)
+        {
+            var serviceBusClient = new ServiceBusClient($"{serviceBusNamespace}.servicebus.windows.net", token);
+            var serviceBusSender = serviceBusClient.CreateSender(serviceBusQueueName);
+            await serviceBusSender.SendMessageAsync(new ServiceBusMessage(message)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <param name="serviceBusConnectionString"></param>
+        /// <param name="serviceBusQueueName"></param>
+        /// <param name="message"></param>
+        /// <returns></returns>
+        public async Task SendToServiceBus(string serviceBusConnectionString, string serviceBusQueueName, ReadOnlyMemory<byte> message)
+        {
+            var serviceBusClient = new ServiceBusClient(serviceBusConnectionString);
+            var serviceBusSender = serviceBusClient.CreateSender(serviceBusQueueName);
+            await serviceBusSender.SendMessageAsync(new ServiceBusMessage(message)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <param name="serviceBusNamespace"></param>
+        /// <param name="serviceBusQueueName"></param>
+        /// <param name="message"></param>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        public async Task SendToServiceBus(string serviceBusNamespace, string serviceBusQueueName, BinaryData message, TokenCredential token)
+        {
+            var serviceBusClient = new ServiceBusClient($"{serviceBusNamespace}.servicebus.windows.net", token);
+            var serviceBusSender = serviceBusClient.CreateSender(serviceBusQueueName);
+            await serviceBusSender.SendMessageAsync(new ServiceBusMessage(message)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <param name="serviceBusConnectionString"></param>
+        /// <param name="serviceBusQueueName"></param>
+        /// <param name="message"></param>
+        /// <returns></returns>
+        public async Task SendToServiceBus(string serviceBusConnectionString, string serviceBusQueueName, BinaryData message)
+        {
+            var serviceBusClient = new ServiceBusClient(serviceBusConnectionString);
+            var serviceBusSender = serviceBusClient.CreateSender(serviceBusQueueName);
+            await serviceBusSender.SendMessageAsync(new ServiceBusMessage(message)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <param name="serviceBusNamespace"></param>
+        /// <param name="serviceBusQueueName"></param>
+        /// <param name="message"></param>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        public async Task SendToServiceBus(string serviceBusNamespace, string serviceBusQueueName, ServiceBusReceivedMessage message, TokenCredential token)
+        {
+            var serviceBusClient = new ServiceBusClient($"{serviceBusNamespace}.servicebus.windows.net", token);
+            var serviceBusSender = serviceBusClient.CreateSender(serviceBusQueueName);
+            await serviceBusSender.SendMessageAsync(new ServiceBusMessage(message)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <param name="serviceBusConnectionString"></param>
+        /// <param name="serviceBusQueueName"></param>
+        /// <param name="message"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
+        public async Task SendToServiceBus(string serviceBusConnectionString, string serviceBusQueueName, ServiceBusReceivedMessage message)
+        {
+            var serviceBusClient = new ServiceBusClient(serviceBusConnectionString);
+            var serviceBusSender = serviceBusClient.CreateSender(serviceBusQueueName);
+            await serviceBusSender.SendMessageAsync(new ServiceBusMessage(message)).ConfigureAwait(false);
+        }
+    }
+}

--- a/Roo.Azure.Configuration.Common/Telemetry/TelemetryInitializer.cs
+++ b/Roo.Azure.Configuration.Common/Telemetry/TelemetryInitializer.cs
@@ -97,7 +97,7 @@ namespace Roo.Azure.Configuration.Common.Telemetry
                         break;
 
                     case Constants.UserInfoUsername:
-                        telemetryValue = HeaderService.GetUserInfoUsername(headers);
+                        telemetryValue = HeaderService.GetUserInfoLoginId(headers);
                         break;
 
                     default:

--- a/Roo.Azure.Configuration.sln
+++ b/Roo.Azure.Configuration.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Roo.Azure.Configuration.Common", "Roo.Azure.Configuration.Common\Roo.Azure.Configuration.Common.csproj", "{11D77E36-0A68-4129-AA5E-B5BE32391E8E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Roo.Azure.Configuration.Common.Http", "Roo.Azure.Configuration.Common.Http\Roo.Azure.Configuration.Common.Http.csproj", "{6F539D26-00A4-4942-A6FD-8564EB36828E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{11D77E36-0A68-4129-AA5E-B5BE32391E8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{11D77E36-0A68-4129-AA5E-B5BE32391E8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{11D77E36-0A68-4129-AA5E-B5BE32391E8E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F539D26-00A4-4942-A6FD-8564EB36828E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F539D26-00A4-4942-A6FD-8564EB36828E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F539D26-00A4-4942-A6FD-8564EB36828E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F539D26-00A4-4942-A6FD-8564EB36828E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
close #15 Client wrapper created for standardized calls, adding headers, and authentication (OAuth, APIM, Basic, pass through)
close #16 Startup configuration simplified into a method,
close #17 Added Azure AD assertion code for authentication with APIM,
close #18 base Enum used so users can pass in their own enums or just use strings

also added service bus wrapper
update most awaits so they're less likely to cause deadlocks