### PR TITLE
add unit tests for Common.Http

### DIFF
--- a/Roo.Azure.Configuration.Common.Http/AzureAdAuthentication/AzureAdClientAssertion.cs
+++ b/Roo.Azure.Configuration.Common.Http/AzureAdAuthentication/AzureAdClientAssertion.cs
@@ -8,6 +8,7 @@ using Roo.Azure.Configuration.Common.Http.Models;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Security.Cryptography.X509Certificates;
+using YamlDotNet.Core.Tokens;
 
 namespace Roo.Azure.Configuration.Common.Http.AzureAdAuthentication
 {
@@ -61,7 +62,13 @@ namespace Roo.Azure.Configuration.Common.Http.AzureAdAuthentication
     /// </summary>
     public class AzureAdClientAssertion : IAzureAdClientAssertion
     {
-        private readonly IMemoryCache _cache;
+        private readonly IMemoryCache? _cache;
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <param name="cache"></param>
+        public AzureAdClientAssertion() { }
 
         /// <summary>
         /// <inheritdoc/>
@@ -110,7 +117,12 @@ namespace Roo.Azure.Configuration.Common.Http.AzureAdAuthentication
         public async Task<string?> GetTokenAsync(string tenantId, string clientId, string scope, X509Certificate2 certificate, string? tokenName = null)
         {
             //Check if token is already in cache
-            var token = !string.IsNullOrEmpty(tokenName) ? _cache.Get<string>(tokenName) : null;
+            string? token = null;
+            if (_cache != null)
+            {
+                token = !string.IsNullOrEmpty(tokenName) ? _cache.Get<string>(tokenName) : null;
+            }
+            
 
             if (!string.IsNullOrEmpty(token))
             {
@@ -142,7 +154,11 @@ namespace Roo.Azure.Configuration.Common.Http.AzureAdAuthentication
         public async Task<string?> GetTokenAsync(string tenantId, string clientId, string scope, string clientSecret, string? tokenName = null)
         {
             //Check if token is already in cache
-            var token = !string.IsNullOrEmpty(tokenName) ? _cache.Get<string>(tokenName) : null;
+            string? token = null;
+            if (_cache != null)
+            {
+                token = !string.IsNullOrEmpty(tokenName) ? _cache.Get<string>(tokenName) : null;
+            }
 
             if (!string.IsNullOrEmpty(token))
             {
@@ -213,7 +229,7 @@ namespace Roo.Azure.Configuration.Common.Http.AzureAdAuthentication
                 {
                     return null;
                 }
-                if (!string.IsNullOrEmpty(tokenName))
+                if (_cache != null && !string.IsNullOrEmpty(tokenName))
                 {
                     _cache.Set(tokenName, token, DateTimeOffset.UtcNow.AddMinutes(58));
                 }

--- a/Roo.Azure.Configuration.Common.Http/AzureAdAuthentication/AzureAdClientAssertionRetriever.cs
+++ b/Roo.Azure.Configuration.Common.Http/AzureAdAuthentication/AzureAdClientAssertionRetriever.cs
@@ -5,7 +5,7 @@ using System.Text.Json;
 
 namespace Roo.Azure.Configuration.Common.Http.AzureAdAuthentication
 {
-    public class AzureAdClientAssertionHelper
+    public class AzureAdClientAssertionRetriever
     {
         private const uint JwtToAadLifetimeInSeconds = 600;
         private readonly static char Base64PadCharacter = '=';

--- a/Roo.Azure.Configuration.Common.Http/IRooHttpClient.cs
+++ b/Roo.Azure.Configuration.Common.Http/IRooHttpClient.cs
@@ -54,8 +54,9 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
         /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
         /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <param name="cancellationToken">Cancellation token to terminate the HTTP call.</param>
         /// <returns></returns>
-        public Task<HttpResponseMessage> GetAsync(string relativeUrl, string httpClientName, List<(string Parameter, string Value)>? queryParameters = null);
+        public Task<HttpResponseMessage> GetAsync(string relativeUrl, string httpClientName, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null);
 
         /// <summary>
         /// GetAsync without object deserialization and an object query parameter.
@@ -64,8 +65,9 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
         /// <param name="httpClientName">Relative URL with query parameters already configured.</param>
         /// <param name="queryStringObject">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <param name="cancellationToken">Cancellation token to terminate the HTTP call.</param>
         /// <returns></returns>
-        public Task<HttpResponseMessage> GetAsync(string relativeUrl, string httpClientName, object queryStringObject);
+        public Task<HttpResponseMessage> GetAsync(string relativeUrl, string httpClientName, object queryStringObject, CancellationToken? cancellationToken = null);
 
         /// <summary>
         /// GetAsync with object deserialization.
@@ -74,8 +76,9 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
         /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
         /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <param name="cancellationToken">Cancellation token to terminate the HTTP call.</param>
         /// <returns></returns>
-        public Task<TResult> GetAsync<TResult>(string relativeUrl, string httpClientName, List<(string Parameter, string Value)>? queryParameters = null);
+        public Task<TResult> GetAsync<TResult>(string relativeUrl, string httpClientName, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null);
 
         /// <summary>
         /// GetAsync with object deserialization and an object query parameter.
@@ -84,47 +87,52 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
         /// <param name="httpClientName">Relative URL with query parameters already configured.</param>
         /// <param name="queryStringObject">Object that will be converted to a query string.</param>
+        /// <param name="cancellationToken">Cancellation token to terminate the HTTP call.</param>
         /// <returns></returns>
-        public Task<TResult> GetAsync<TResult>(string relativeUrl, string httpClientName, object queryStringObject);
+        public Task<TResult> GetAsync<TResult>(string relativeUrl, string httpClientName, object queryStringObject, CancellationToken? cancellationToken = null);
 
         /// <summary>
-        /// <inheritdoc cref="GetAsync(string, string, List{ValueTuple{string, string}}?)"/>
+        /// <inheritdoc cref="GetAsync(string, string, List{ValueTuple{string, string}}?, CancellationToken?)"/>
         /// </summary>
         /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
         /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
         /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <param name="cancellationToken">Cancellation token to terminate the HTTP call.</param>
         /// <returns></returns>
-        public Task<HttpResponseMessage> GetAsync(string relativeUrl, Enum httpClientName, List<(string Parameter, string Value)>? queryParameters = null);
+        public Task<HttpResponseMessage> GetAsync(string relativeUrl, Enum httpClientName, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null);
 
         /// <summary>
-        /// <inheritdoc cref="GetAsync(string, string, object)"/>
+        /// <inheritdoc cref="GetAsync(string, string, object, CancellationToken?)"/>
         /// </summary>
         /// <typeparam name="TResult"></typeparam>
         /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
         /// <param name="httpClientName">Relative URL with query parameters already configured.</param>
         /// <param name="queryStringObject">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <param name="cancellationToken">Cancellation token to terminate the HTTP call.</param>
         /// <returns></returns>
-        public Task<HttpResponseMessage> GetAsync(string relativeUrl, Enum httpClientName, object queryStringObject);
+        public Task<HttpResponseMessage> GetAsync(string relativeUrl, Enum httpClientName, object queryStringObject, CancellationToken? cancellationToken = null);
 
         /// <summary>
-        /// <inheritdoc cref="GetAsync{TResult}(string, string, List{ValueTuple{string, string}}?)"/>
+        /// <inheritdoc cref="GetAsync{TResult}(string, string, List{ValueTuple{string, string}}?, CancellationToken?)"/>
         /// </summary>
         /// <typeparam name="TResult">Object that response should be deserialized into.</typeparam>
         /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
         /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
         /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <param name="cancellationToken">Cancellation token to terminate the HTTP call.</param>
         /// <returns></returns>
-        public Task<TResult> GetAsync<TResult>(string relativeUrl, Enum httpClientName, List<(string Parameter, string Value)>? queryParameters = null);
+        public Task<TResult> GetAsync<TResult>(string relativeUrl, Enum httpClientName, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null);
 
         /// <summary>
-        /// <inheritdoc cref="GetAsync{TResult}(string, string, object)"/>
+        /// <inheritdoc cref="GetAsync{TResult}(string, string, object, CancellationToken?)"/>
         /// </summary>
         /// <typeparam name="TResult">Object that response should be deserialized into.</typeparam>
         /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
         /// <param name="httpClientName">Relative URL with query parameters already configured.</param>
         /// <param name="queryStringObject">Object that will be converted to a query string.</param>
+        /// <param name="cancellationToken">Cancellation token to terminate the HTTP call.</param>
         /// <returns></returns>
-        public Task<TResult> GetAsync<TResult>(string relativeUrl, Enum httpClientName, object queryStringObject);
+        public Task<TResult> GetAsync<TResult>(string relativeUrl, Enum httpClientName, object queryStringObject, CancellationToken? cancellationToken = null);
 
         /// <summary>
         /// PostAsync without object deserialization.
@@ -136,8 +144,9 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="formData">MultipartFormDataContent to be sent with POST. Will be ignored if object or HttpContent is used but takes precedence over MultipartContent if more than one is used.</param>
         /// <param name="multipartContent">MultipartContent to be sent with POST. Will be ignored if object, HttpContent, or MultipartFormDataContent if more than one is used.</param>
         /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <param name="cancellationToken">Cancellation token to terminate the HTTP call.</param>
         /// <returns></returns>
-        public Task<HttpResponseMessage> PostAsync(string relativeUrl, string httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null);
+        public Task<HttpResponseMessage> PostAsync(string relativeUrl, string httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null);
 
         /// <summary>
         /// PostAsync with object deserialization.
@@ -147,11 +156,12 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
         /// <param name="data">Object to be sent with POST. Takes precedence over HttpContent, MultipartFormDataContent, and MultipartContent if more than one is used.</param>
         /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <param name="cancellationToken">Cancellation token to terminate the HTTP call.</param>
         /// <returns></returns>
-        public Task<TResult> PostAsync<TResult>(string relativeUrl, string httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null);
+        public Task<TResult> PostAsync<TResult>(string relativeUrl, string httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null);
 
         /// <summary>
-        /// <inheritdoc cref="PostAsync(string, string, object?, List{ValueTuple{string, string}}?)"/>
+        /// <inheritdoc cref="PostAsync(string, string, object?, List{ValueTuple{string, string}}?, CancellationToken?)"/>
         /// </summary>
         /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
         /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
@@ -160,19 +170,21 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="formData">MultipartFormDataContent to be sent with POST. Will be ignored if object or HttpContent is used but takes precedence over MultipartContent if more than one is used.</param>
         /// <param name="multipartContent">MultipartContent to be sent with POST. Will be ignored if object, HttpContent, or MultipartFormDataContent if more than one is used.</param>
         /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <param name="cancellationToken">Cancellation token to terminate the HTTP call.</param>
         /// <returns></returns>
-        public Task<HttpResponseMessage> PostAsync(string relativeUrl, Enum httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null);
+        public Task<HttpResponseMessage> PostAsync(string relativeUrl, Enum httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null);
 
         /// <summary>
-        /// <inheritdoc cref="PostAsync{TResult}(string, string, object?, List{ValueTuple{string, string}}?)"/>
+        /// <inheritdoc cref="PostAsync{TResult}(string, string, object?, List{ValueTuple{string, string}}?, CancellationToken?)"/>
         /// </summary>
         /// <typeparam name="TResult">Object that response should be deserialized into.</typeparam>
         /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
         /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
         /// <param name="data">Object to be sent with POST. Takes precedence over HttpContent, MultipartFormDataContent, and MultipartContent if more than one is used.</param>
         /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <param name="cancellationToken">Cancellation token to terminate the HTTP call.</param>
         /// <returns></returns>
-        public Task<TResult> PostAsync<TResult>(string relativeUrl, Enum httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null);
+        public Task<TResult> PostAsync<TResult>(string relativeUrl, Enum httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null);
 
         /// <summary>
         /// PutAsync without object deserialization.
@@ -181,8 +193,9 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
         /// <param name="data">Object to be sent with PUT. Takes precedence over HttpContent, MultipartFormDataContent, and MultipartContent if more than one is used.</param>
         /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <param name="cancellationToken">Cancellation token to terminate the HTTP call.</param>
         /// <returns></returns>
-        public Task<HttpResponseMessage> PutAsync(string relativeUrl, string httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null);
+        public Task<HttpResponseMessage> PutAsync(string relativeUrl, string httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null);
 
         /// <summary>
         /// PutAsync with object deserialization.
@@ -192,29 +205,32 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
         /// <param name="data">Object to be sent with PUT. Takes precedence over HttpContent, MultipartFormDataContent, and MultipartContent if more than one is used.</param>
         /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <param name="cancellationToken">Cancellation token to terminate the HTTP call.</param>
         /// <returns></returns>
-        public Task<TResult> PutAsync<TResult>(string relativeUrl, string httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null);
+        public Task<TResult> PutAsync<TResult>(string relativeUrl, string httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null);
 
         /// <summary>
-        /// <inheritdoc cref="PutAsync(string, string, object?, List{ValueTuple{string, string}}?)"/>
+        /// <inheritdoc cref="PutAsync(string, string, object?, List{ValueTuple{string, string}}?, CancellationToken?)"/>
         /// </summary>
         /// <param name="relativeUrl"><Relative URL with query parameters already configured, unless a query Dictionary is used.></param>
         /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
         /// <param name="data">Object to be sent with PUT. Takes precedence over HttpContent, MultipartFormDataContent, and MultipartContent if more than one is used.</param>
         /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <param name="cancellationToken">Cancellation token to terminate the HTTP call.</param>
         /// <returns></returns>
-        public Task<HttpResponseMessage> PutAsync(string relativeUrl, Enum httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null);
+        public Task<HttpResponseMessage> PutAsync(string relativeUrl, Enum httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null);
 
         /// <summary>
-        /// <inheritdoc cref="PutAsync{TResult}(string, string, object?, List{ValueTuple{string, string}}?)"/>
+        /// <inheritdoc cref="PutAsync{TResult}(string, string, object?, List{ValueTuple{string, string}}?, CancellationToken?)"/>
         /// </summary>
         /// <typeparam name="TResult">Object that response should be deserialized into.</typeparam>
         /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
         /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
         /// <param name="data">Object to be sent with PUT. Takes precedence over HttpContent, MultipartFormDataContent, and MultipartContent if more than one is used.</param>
         /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <param name="cancellationToken">Cancellation token to terminate the HTTP call.</param>
         /// <returns></returns>
-        public Task<TResult> PutAsync<TResult>(string relativeUrl, Enum httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null);
+        public Task<TResult> PutAsync<TResult>(string relativeUrl, Enum httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null);
 
         /// <summary>
         /// DeleteAsync with object deserialization.
@@ -223,8 +239,9 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
         /// <param name="data">Object to be sent with DELETE. Takes precedence over HttpContent, MultipartFormDataContent, and MultipartContent if more than one is used.</param>
         /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <param name="cancellationToken">Cancellation token to terminate the HTTP call.</param>
         /// <returns></returns>
-        public Task<HttpResponseMessage> DeleteAsync(string relativeUrl, string httpClientName, List<(string Parameter, string Value)>? queryParameters = null);
+        public Task<HttpResponseMessage> DeleteAsync(string relativeUrl, string httpClientName, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null);
 
         /// <summary>
         /// DeleteAsync with object deserialization.
@@ -234,35 +251,38 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
         /// <param name="data">Object to be sent with DELETE. Takes precedence over HttpContent, MultipartFormDataContent, and MultipartContent if more than one is used.</param>
         /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <param name="cancellationToken">Cancellation token to terminate the HTTP call.</param>
         /// <returns></returns>
-        public Task<TResult> DeleteAsync<TResult>(string relativeUrl, string httpClientName, List<(string Parameter, string Value)>? queryParameters = null);
+        public Task<TResult> DeleteAsync<TResult>(string relativeUrl, string httpClientName, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null);
 
         /// <summary>
-        /// <inheritdoc cref="DeleteAsync(string, string, List{ValueTuple{string, string}}?)"/>>
+        /// <inheritdoc cref="DeleteAsync(string, string, List{ValueTuple{string, string}}?, CancellationToken?)"/>>
         /// </summary>
         /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
         /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
         /// <param name="data">Object to be sent with DELETE. Takes precedence over HttpContent, MultipartFormDataContent, and MultipartContent if more than one is used.</param>
         /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <param name="cancellationToken">Cancellation token to terminate the HTTP call.</param>
         /// <returns></returns>
-        public Task<HttpResponseMessage> DeleteAsync(string relativeUrl, Enum httpClientName, List<(string Parameter, string Value)>? queryParameters = null);
+        public Task<HttpResponseMessage> DeleteAsync(string relativeUrl, Enum httpClientName, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null);
 
         /// <summary>
-        /// <inheritdoc cref="DeleteAsync{TResult}(string, string, List{ValueTuple{string, string}}?)"/>
+        /// <inheritdoc cref="DeleteAsync{TResult}(string, string, List{ValueTuple{string, string}}?, CancellationToken?)"/>
         /// </summary>
         /// <typeparam name="TResult">Object that response should be deserialized into.</typeparam>
         /// <param name="relativeUrl">Relative URL with query parameters already configured, unless a query Dictionary is used.</param>
         /// <param name="httpClientName">Name of client; either a client configured at startup or, if a non-configured client is used, then the base URL must included with with the relative URL.</param>
         /// <param name="data">Object to be sent with DELETE. Takes precedence over HttpContent, MultipartFormDataContent, and MultipartContent if more than one is used.</param>
         /// <param name="queryParameters">Dictionary of query parameter names and values that will be configured and appended to URL.</param>
+        /// <param name="cancellationToken">Cancellation token to terminate the HTTP call.</param>
         /// <returns></returns>
-        public Task<TResult> DeleteAsync<TResult>(string relativeUrl, Enum httpClientName, List<(string Parameter, string Value)>? queryParameters = null);
+        public Task<TResult> DeleteAsync<TResult>(string relativeUrl, Enum httpClientName, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null);
 
         /// <summary>
-        /// Clears existing token currently stored in Redis.
+        /// Clears existing token currently stored in cache. If RooHttpClient was initialized without a cache then this does nothing.
         /// </summary>
-        /// <param name="tokeName">Name of token stored in Redis.</param>
+        /// <param name="tokeName">Name of token stored in cache.</param>
         /// <returns></returns>
-        public Task<bool> ClearToken(string tokeName);
+        public Task<bool> ClearToken(string? tokeName = null);
     }
 }

--- a/Roo.Azure.Configuration.Common.Http/RooHttpClient.cs
+++ b/Roo.Azure.Configuration.Common.Http/RooHttpClient.cs
@@ -125,20 +125,37 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="relativeUrl"></param>
         /// <param name="httpClientName"></param>
         /// <param name="queryParameters"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<HttpResponseMessage> GetAsync(string relativeUrl, string httpClientName, List<(string Parameter, string Value)>? queryParameters = null)
+        public async Task<HttpResponseMessage> GetAsync(string relativeUrl, string httpClientName, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null)
         {
             if (queryParameters != null)
             {
+                relativeUrl = relativeUrl.TrimEnd('/');
                 relativeUrl += ToQueryString(queryParameters);
             }
             var httpClient = await HttpClientSetup(httpClientName).ConfigureAwait(false);
-            var response = await httpClient.GetAsync(relativeUrl).ConfigureAwait(false);
-            if (response.StatusCode == HttpStatusCode.Unauthorized && AuthenticationInfo != null)
+            HttpResponseMessage? response = null;
+            if (cancellationToken == null)
             {
-                AddBearerToken(await GetToken(httpClientName, true).ConfigureAwait(false) ?? "", httpClient);
                 response = await httpClient.GetAsync(relativeUrl).ConfigureAwait(false);
             }
+            else
+            {
+                response = await httpClient.GetAsync(relativeUrl, (CancellationToken)cancellationToken).ConfigureAwait(false);
+            }
+            if (response.StatusCode == HttpStatusCode.Unauthorized && AuthenticationInfo != null)
+            {
+                AddBearerToken(await GetToken(httpClientName, true).ConfigureAwait(false) ?? "", httpClient);
+                if (cancellationToken == null)
+                {
+                    response = await httpClient.GetAsync(relativeUrl).ConfigureAwait(false);
+                }
+                else
+                {
+                    response = await httpClient.GetAsync(relativeUrl, (CancellationToken)cancellationToken).ConfigureAwait(false);
+                }
+            }
             return response;
         }
 
@@ -148,11 +165,13 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="relativeUrl"></param>
         /// <param name="httpClientName"></param>
         /// <param name="queryStringObject"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<HttpResponseMessage> GetAsync(string relativeUrl, string httpClientName, object queryStringObject)
+        public async Task<HttpResponseMessage> GetAsync(string relativeUrl, string httpClientName, object queryStringObject, CancellationToken? cancellationToken = null)
         {
+            relativeUrl = relativeUrl.TrimEnd('/');
             relativeUrl += ToQueryString(queryStringObject);
-            var response = await GetAsync(relativeUrl, httpClientName).ConfigureAwait(false);
+            var response = await GetAsync(relativeUrl, httpClientName, null, cancellationToken).ConfigureAwait(false);
             return response;
         }
 
@@ -163,10 +182,11 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="relativeUrl"></param>
         /// <param name="httpClientName"></param>
         /// <param name="queryParameters"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<TResult> GetAsync<TResult>(string relativeUrl, string httpClientName, List<(string Parameter, string Value)>? queryParameters = null)
+        public async Task<TResult> GetAsync<TResult>(string relativeUrl, string httpClientName, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null)
         {
-            var response = await GetAsync(relativeUrl, httpClientName, queryParameters).ConfigureAwait(false);
+            var response = await GetAsync(relativeUrl, httpClientName, queryParameters, cancellationToken).ConfigureAwait(false);
             return await DeserializeResult<TResult>(response).ConfigureAwait(false);
         }
 
@@ -177,11 +197,11 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="relativeUrl"></param>
         /// <param name="httpClientName"></param>
         /// <param name="queryStringObject"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<TResult> GetAsync<TResult>(string relativeUrl, string httpClientName, object queryStringObject)
+        public async Task<TResult> GetAsync<TResult>(string relativeUrl, string httpClientName, object queryStringObject, CancellationToken? cancellationToken = null)
         {
-            relativeUrl += ToQueryString(queryStringObject);
-            var response = await GetAsync(relativeUrl, httpClientName).ConfigureAwait(false);
+            var response = await GetAsync(relativeUrl, httpClientName, queryStringObject, cancellationToken).ConfigureAwait(false);
             return await DeserializeResult<TResult>(response).ConfigureAwait(false);
         }
 
@@ -191,10 +211,11 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="relativeUrl"></param>
         /// <param name="httpClientName"></param>
         /// <param name="queryParameters"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<HttpResponseMessage> GetAsync(string relativeUrl, Enum httpClientName, List<(string Parameter, string Value)>? queryParameters = null)
+        public async Task<HttpResponseMessage> GetAsync(string relativeUrl, Enum httpClientName, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null)
         {
-            return await GetAsync(relativeUrl, httpClientName.ToString(), queryParameters).ConfigureAwait(false);
+            return await GetAsync(relativeUrl, httpClientName.ToString(), queryParameters, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -203,10 +224,11 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="relativeUrl"></param>
         /// <param name="httpClientName"></param>
         /// <param name="queryStringObject"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<HttpResponseMessage> GetAsync(string relativeUrl, Enum httpClientName, object queryStringObject)
+        public async Task<HttpResponseMessage> GetAsync(string relativeUrl, Enum httpClientName, object queryStringObject, CancellationToken? cancellationToken = null)
         {
-            return await GetAsync(relativeUrl, httpClientName.ToString(), queryStringObject).ConfigureAwait(false);
+            return await GetAsync(relativeUrl, httpClientName.ToString(), queryStringObject, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -216,10 +238,11 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="relativeUrl"></param>
         /// <param name="httpClientName"></param>
         /// <param name="queryParameters"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<TResult> GetAsync<TResult>(string relativeUrl, Enum httpClientName, List<(string Parameter, string Value)>? queryParameters = null)
+        public async Task<TResult> GetAsync<TResult>(string relativeUrl, Enum httpClientName, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null)
         {
-            return await GetAsync<TResult>(relativeUrl, httpClientName.ToString(), queryParameters).ConfigureAwait(false);
+            return await GetAsync<TResult>(relativeUrl, httpClientName.ToString(), queryParameters, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -229,10 +252,11 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="relativeUrl"></param>
         /// <param name="httpClientName"></param>
         /// <param name="queryStringObject"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<TResult> GetAsync<TResult>(string relativeUrl, Enum httpClientName, object queryStringObject)
+        public async Task<TResult> GetAsync<TResult>(string relativeUrl, Enum httpClientName, object queryStringObject, CancellationToken? cancellationToken = null)
         {
-            return await GetAsync<TResult>(relativeUrl, httpClientName.ToString(), queryStringObject).ConfigureAwait(false);
+            return await GetAsync<TResult>(relativeUrl, httpClientName.ToString(), queryStringObject, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -242,8 +266,9 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="httpClientName"></param>
         /// <param name="data"></param>
         /// <param name="queryParameters"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<HttpResponseMessage> PostAsync(string relativeUrl, string httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null)
+        public async Task<HttpResponseMessage> PostAsync(string relativeUrl, string httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null)
         {
             HttpContent? content = null;
             if (data != null)
@@ -255,11 +280,7 @@ namespace Roo.Azure.Configuration.Common.Http
                 }
                 else
                 {
-                    if (data is HttpContent)
-                    {
-                        content = (HttpContent?)data;
-                    }
-                    else if (data is MultipartFormDataContent)
+                    if (data is MultipartFormDataContent)
                     {
                         content = (MultipartFormDataContent?)data;
                     }
@@ -267,19 +288,39 @@ namespace Roo.Azure.Configuration.Common.Http
                     {
                         content = (MultipartContent?)data;
                     }
+                    else if (data is HttpContent)
+                    {
+                        content = (HttpContent?)data;
+                    }
                 }
             }
             if (queryParameters != null)
             {
+                relativeUrl = relativeUrl.TrimEnd('/');
                 relativeUrl += ToQueryString(queryParameters);
             }
             var httpClient = await HttpClientSetup(httpClientName).ConfigureAwait(false);
-            var response = await httpClient.PostAsync(relativeUrl, content).ConfigureAwait(false);
-            if (response.StatusCode == HttpStatusCode.Unauthorized && AuthenticationInfo != null)
+            HttpResponseMessage? response = null;
+            if (cancellationToken == null)
             {
-                AddBearerToken(await GetToken(httpClientName, true).ConfigureAwait(false) ?? "", httpClient);
                 response = await httpClient.PostAsync(relativeUrl, content).ConfigureAwait(false);
             }
+            else
+            {
+                response = await httpClient.PostAsync(relativeUrl, content, (CancellationToken)cancellationToken).ConfigureAwait(false);
+            }
+            if (response.StatusCode == HttpStatusCode.Unauthorized && AuthenticationInfo != null)
+            {
+                AddBearerToken(await GetToken(httpClientName, true).ConfigureAwait(false) ?? "", httpClient);
+                if (cancellationToken == null)
+                {
+                    response = await httpClient.PostAsync(relativeUrl, content).ConfigureAwait(false);
+                }
+                else
+                {
+                    response = await httpClient.PostAsync(relativeUrl, content, (CancellationToken)cancellationToken).ConfigureAwait(false);
+                }
+            }
             return response;
         }
 
@@ -291,10 +332,11 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="httpClientName"></param>
         /// <param name="data"></param>
         /// <param name="queryParameters"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<TResult> PostAsync<TResult>(string relativeUrl, string httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null)
+        public async Task<TResult> PostAsync<TResult>(string relativeUrl, string httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null)
         {
-            var response = await PostAsync(relativeUrl, httpClientName, data, queryParameters).ConfigureAwait(false);
+            var response = await PostAsync(relativeUrl, httpClientName, data, queryParameters, cancellationToken).ConfigureAwait(false);
             return await DeserializeResult<TResult>(response).ConfigureAwait(false);
         }
 
@@ -305,10 +347,11 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="httpClientName"></param>
         /// <param name="data"></param>
         /// <param name="queryParameters"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<HttpResponseMessage> PostAsync(string relativeUrl, Enum httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null)
+        public async Task<HttpResponseMessage> PostAsync(string relativeUrl, Enum httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null)
         {
-            return await PostAsync(relativeUrl, httpClientName.ToString(), data, queryParameters).ConfigureAwait(false);
+            return await PostAsync(relativeUrl, httpClientName.ToString(), data, queryParameters, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -319,10 +362,11 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="httpClientName"></param>
         /// <param name="data"></param>
         /// <param name="queryParameters"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<TResult> PostAsync<TResult>(string relativeUrl, Enum httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null)
+        public async Task<TResult> PostAsync<TResult>(string relativeUrl, Enum httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null)
         {
-            return await PostAsync<TResult>(relativeUrl, httpClientName.ToString(), data, queryParameters).ConfigureAwait(false);
+            return await PostAsync<TResult>(relativeUrl, httpClientName.ToString(), data, queryParameters, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -332,8 +376,9 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="httpClientName"></param>
         /// <param name="data"></param>
         /// <param name="queryParameters"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<HttpResponseMessage> PutAsync(string relativeUrl, string httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null)
+        public async Task<HttpResponseMessage> PutAsync(string relativeUrl, string httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null)
         {
             HttpContent? content = null;
             if (data != null)
@@ -345,11 +390,7 @@ namespace Roo.Azure.Configuration.Common.Http
                 }
                 else
                 {
-                    if (data is HttpContent)
-                    {
-                        content = (HttpContent?)data;
-                    }
-                    else if (data is MultipartFormDataContent)
+                    if (data is MultipartFormDataContent)
                     {
                         content = (MultipartFormDataContent?)data;
                     }
@@ -357,18 +398,38 @@ namespace Roo.Azure.Configuration.Common.Http
                     {
                         content = (MultipartContent?)data;
                     }
+                    else if (data is HttpContent)
+                    {
+                        content = (HttpContent?)data;
+                    }
                 }
             }
             if (queryParameters != null)
             {
+                relativeUrl = relativeUrl.TrimEnd('/');
                 relativeUrl += ToQueryString(queryParameters);
             }
             var httpClient = await HttpClientSetup(httpClientName).ConfigureAwait(false);
-            var response = await httpClient.PutAsync(relativeUrl, content).ConfigureAwait(false);
+            HttpResponseMessage? response = null;
+            if (cancellationToken == null)
+            {
+                response = await httpClient.PutAsync(relativeUrl, content).ConfigureAwait(false);
+            }
+            else
+            {
+                response = await httpClient.PutAsync(relativeUrl, content, (CancellationToken)cancellationToken).ConfigureAwait(false);
+            }
             if (response.StatusCode == HttpStatusCode.Unauthorized && AuthenticationInfo != null)
             {
                 AddBearerToken(await GetToken(httpClientName, true).ConfigureAwait(false) ?? "", httpClient);
-                response = await httpClient.PutAsync(relativeUrl, content).ConfigureAwait(false);
+                if (cancellationToken == null)
+                {
+                    response = await httpClient.PutAsync(relativeUrl, content).ConfigureAwait(false);
+                }
+                else
+                {
+                    response = await httpClient.PutAsync(relativeUrl, content, (CancellationToken)cancellationToken).ConfigureAwait(false);
+                }
             }
             return response;
         }
@@ -381,10 +442,11 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="httpClientName"></param>
         /// <param name="data"></param>
         /// <param name="queryParameters"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<TResult> PutAsync<TResult>(string relativeUrl, string httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null)
+        public async Task<TResult> PutAsync<TResult>(string relativeUrl, string httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null)
         {
-            var response = await PutAsync(relativeUrl, httpClientName, data, queryParameters).ConfigureAwait(false);
+            var response = await PutAsync(relativeUrl, httpClientName, data, queryParameters, cancellationToken).ConfigureAwait(false);
             return await DeserializeResult<TResult>(response).ConfigureAwait(false);
         }
 
@@ -395,10 +457,11 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="httpClientName"></param>
         /// <param name="data"></param>
         /// <param name="queryParameters"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<HttpResponseMessage> PutAsync(string relativeUrl, Enum httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null)
+        public async Task<HttpResponseMessage> PutAsync(string relativeUrl, Enum httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null)
         {
-            return await PutAsync(relativeUrl, httpClientName.ToString(), data, queryParameters).ConfigureAwait(false);
+            return await PutAsync(relativeUrl, httpClientName.ToString(), data, queryParameters, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -409,10 +472,11 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="httpClientName"></param>
         /// <param name="data"></param>
         /// <param name="queryParameters"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<TResult> PutAsync<TResult>(string relativeUrl, Enum httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null)
+        public async Task<TResult> PutAsync<TResult>(string relativeUrl, Enum httpClientName, object? data = null, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null)
         {
-            return await PutAsync<TResult>(relativeUrl, httpClientName.ToString(), data, queryParameters).ConfigureAwait(false);
+            return await PutAsync<TResult>(relativeUrl, httpClientName.ToString(), data, queryParameters, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -421,19 +485,36 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="relativeUrl"></param>
         /// <param name="httpClientName"></param>
         /// <param name="queryParameters"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<HttpResponseMessage> DeleteAsync(string relativeUrl, string httpClientName, List<(string Parameter, string Value)>? queryParameters = null)
+        public async Task<HttpResponseMessage> DeleteAsync(string relativeUrl, string httpClientName, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null)
         {
             if (queryParameters != null)
             {
+                relativeUrl = relativeUrl.TrimEnd('/');
                 relativeUrl += ToQueryString(queryParameters);
             }
             var httpClient = await HttpClientSetup(httpClientName).ConfigureAwait(false);
-            var response = await httpClient.DeleteAsync(relativeUrl).ConfigureAwait(false);
+            HttpResponseMessage? response = null;
+            if (cancellationToken == null)
+            {
+                response = await httpClient.DeleteAsync(relativeUrl).ConfigureAwait(false);
+            }
+            else
+            {
+                response = await httpClient.DeleteAsync(relativeUrl, (CancellationToken)cancellationToken).ConfigureAwait(false);
+            }
             if (response.StatusCode == HttpStatusCode.Unauthorized && AuthenticationInfo != null)
             {
                 AddBearerToken(await GetToken(httpClientName, true).ConfigureAwait(false) ?? "", httpClient);
-                response = await httpClient.DeleteAsync(relativeUrl).ConfigureAwait(false);
+                if (cancellationToken == null)
+                {
+                    response = await httpClient.DeleteAsync(relativeUrl).ConfigureAwait(false);
+                }
+                else
+                {
+                    response = await httpClient.DeleteAsync(relativeUrl, (CancellationToken)cancellationToken).ConfigureAwait(false);
+                }
             }
             return response;
         }
@@ -445,10 +526,11 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="relativeUrl"></param>
         /// <param name="httpClientName"></param>
         /// <param name="queryParameters"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<TResult> DeleteAsync<TResult>(string relativeUrl, string httpClientName, List<(string Parameter, string Value)>? queryParameters = null)
+        public async Task<TResult> DeleteAsync<TResult>(string relativeUrl, string httpClientName, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null)
         {
-            var response = await DeleteAsync(relativeUrl, httpClientName, queryParameters).ConfigureAwait(false);
+            var response = await DeleteAsync(relativeUrl, httpClientName, queryParameters, cancellationToken).ConfigureAwait(false);
             return await DeserializeResult<TResult>(response).ConfigureAwait(false);
         }
 
@@ -458,10 +540,11 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="relativeUrl"></param>
         /// <param name="httpClientName"></param>
         /// <param name="queryParameters"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<HttpResponseMessage> DeleteAsync(string relativeUrl, Enum httpClientName, List<(string Parameter, string Value)>? queryParameters = null)
+        public async Task<HttpResponseMessage> DeleteAsync(string relativeUrl, Enum httpClientName, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null)
         {
-            return await DeleteAsync(relativeUrl, httpClientName.ToString(), queryParameters).ConfigureAwait(false);
+            return await DeleteAsync(relativeUrl, httpClientName.ToString(), queryParameters, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -471,10 +554,11 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="relativeUrl"></param>
         /// <param name="httpClientName"></param>
         /// <param name="queryParameters"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<TResult> DeleteAsync<TResult>(string relativeUrl, Enum httpClientName, List<(string Parameter, string Value)>? queryParameters = null)
+        public async Task<TResult> DeleteAsync<TResult>(string relativeUrl, Enum httpClientName, List<(string Parameter, string Value)>? queryParameters = null, CancellationToken? cancellationToken = null)
         {
-            return await DeleteAsync<TResult>(relativeUrl, httpClientName.ToString(), queryParameters).ConfigureAwait(false);
+            return await DeleteAsync<TResult>(relativeUrl, httpClientName.ToString(), queryParameters, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -658,27 +742,29 @@ namespace Roo.Azure.Configuration.Common.Http
 
         private async Task<string?> GetToken(string httpClientName, bool forceToken = false)
         {
-            if (AuthenticationInfo == null || string.IsNullOrEmpty(AuthenticationInfo.TokenName))
+            if (AuthenticationInfo == null)
             {
                 return null;
-            }
-
-            if (AuthenticationInfo.ForceToken || forceToken)
-            {
-                _logger.LogInformation(HttpContext, "Deleting stored token and requesting a new one.");
-                await ClearToken().ConfigureAwait(false);
             }
 
             await _semaphoreSlim.WaitAsync();
 
             string? token = null;
-            if (_redisService != null)
+            if (AuthenticationInfo.ForceToken || forceToken)
             {
-                token = await _redisService.Get(AuthenticationInfo.TokenName ?? httpClientName);
+                _logger.LogInformation(HttpContext, "Deleting stored token and requesting a new one.");
+                await ClearToken(httpClientName).ConfigureAwait(false);
             }
-            else if (_cache != null)
+            else
             {
-                token = _cache.Get<string>(AuthenticationInfo.TokenName ?? httpClientName);
+                if (_redisService != null)
+                {
+                    token = await _redisService.Get(AuthenticationInfo.TokenName ?? httpClientName);
+                }
+                else if (_cache != null)
+                {
+                    token = _cache.Get<string>(AuthenticationInfo.TokenName ?? httpClientName);
+                }
             }
 
             try

--- a/Roo.Azure.Configuration.Common.Http/RooHttpClientConfiguration.cs
+++ b/Roo.Azure.Configuration.Common.Http/RooHttpClientConfiguration.cs
@@ -20,11 +20,11 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="services"></param>
         /// <param name="channelId">Channel Id of application.</param>
         /// <param name="httpClients">List of HttpClient names (as strings) and base URLs to configure.</param>
-        /// <param name="useMemoryCache">Whether to use memory cache when storing tokens. Redis takes precedence if Redis connection string is passed in.</param>
+        /// <param name="useMemoryCache">Whether to use memory cache when storing tokens. Redis takes precedence if Redis connection string is passed in too. Memory cache will be used with Azure APIM if neither is passed in.</param>
         /// <param name="redisConnectionString">Connection string to Redis, controls whether to use Redis when storing tokens. Takes precedence over memory cache.</param>
         /// <param name=""></param>
         /// <returns></returns>
-        public static IServiceCollection RooHttpClientConfig(this IServiceCollection services, string channelId, List<(string Name, string BaseUrl)> httpClients, bool useMemoryCache = false, string? redisConnectionString = null)
+        public static IServiceCollection RooHttpClientConfig(this IServiceCollection services, string channelId, List<(string Name, string BaseUrl)> httpClients, string? redisConnectionString = null, bool useMemoryCache = false)
         {
             //Iterate through client list and create named client for each item
             foreach (var httpClient in httpClients)
@@ -38,7 +38,7 @@ namespace Roo.Azure.Configuration.Common.Http
                     config.BaseAddress = new Uri(httpClient.BaseUrl);
                 }).AddHttpMessageHandler<HeaderPropagateMiddleware>();
             }
-            return CreateHttpClient(services, channelId, useMemoryCache, redisConnectionString);
+            return CreateHttpClient(services, channelId, redisConnectionString, useMemoryCache);
         }
 
         /// <summary>
@@ -47,11 +47,11 @@ namespace Roo.Azure.Configuration.Common.Http
         /// <param name="services"></param>
         /// <param name="channelId">Channel Id of application.</param>
         /// <param name="httpClients">List of HttpClient names (as enums) and base URLs to configure.</param>
-        /// <param name="useMemoryCache">Whether to use memory cache when storing tokens. Redis takes precedence if Redis connection string is passed in.</param>
+        /// <param name="useMemoryCache">Whether to use memory cache when storing tokens. Redis takes precedence if Redis connection string is passed in too. Memory cache will be used with Azure APIM if neither is passed in.</param>
         /// <param name="redisConnectionString">Connection string to Redis, controls whether to use Redis when storing tokens. Takes precedence over memory cache.</param>
         /// <param name=""></param>
         /// <returns></returns>
-        public static IServiceCollection RooHttpClientConfig(this IServiceCollection services, string channelId, List<(Enum Name, string BaseUrl)> httpClients, bool useMemoryCache = false, string? redisConnectionString = null)
+        public static IServiceCollection RooHttpClientConfig(this IServiceCollection services, string channelId, List<(Enum Name, string BaseUrl)> httpClients, string? redisConnectionString = null, bool useMemoryCache = false)
         {
             //Iterate through client list and create named client for each item
             foreach (var httpClient in httpClients)
@@ -65,13 +65,27 @@ namespace Roo.Azure.Configuration.Common.Http
                     config.BaseAddress = new Uri(httpClient.BaseUrl);
                 }).AddHttpMessageHandler<HeaderPropagateMiddleware>();
             }
-            return CreateHttpClient(services, channelId, useMemoryCache, redisConnectionString);
+            return CreateHttpClient(services, channelId, redisConnectionString, useMemoryCache);
         }
 
-        private static IServiceCollection CreateHttpClient(IServiceCollection services, string channelId, bool useMemoryCache = false, string? redisConnectionString = null)
+        private static IServiceCollection CreateHttpClient(IServiceCollection services, string channelId, string? redisConnectionString = null, bool useMemoryCache = false)
         {
             //Add Azure Active Directory authentication service
-            services.TryAddSingleton<IAzureAdClientAssertion, AzureAdClientAssertion>();
+            if (string.IsNullOrEmpty(redisConnectionString) && useMemoryCache == false)
+            {
+                services.TryAddSingleton<IAzureAdClientAssertion>(x =>
+                {
+                    var cache = x.GetRequiredService<IMemoryCache>();
+                    return new AzureAdClientAssertion(cache);
+                });
+            }
+            else
+            {
+                services.TryAddSingleton<IAzureAdClientAssertion>(x =>
+                {
+                    return new AzureAdClientAssertion();
+                });
+            }
 
             //Create RooHttpClient
             if (!string.IsNullOrEmpty(redisConnectionString))

--- a/Roo.Azure.Configuration.Tests/UnitTests/CertificateValidationServiceTests.cs
+++ b/Roo.Azure.Configuration.Tests/UnitTests/CertificateValidationServiceTests.cs
@@ -6,10 +6,7 @@ namespace Roo.Azure.Configuration.Tests.UnitTests
     public class CertificateValidationServiceTests
     {
         //Common
-        string validThumbprint = "validThumbPrint";
-
-        [SetUp]
-        public void Setup() { }
+        private string validThumbprint = "validThumbPrint";
 
         [Test]
         public void ValidateCertificateFailInvalid_Verify()

--- a/Roo.Azure.Configuration.Tests/UnitTests/FeatureManagerServiceTests.cs
+++ b/Roo.Azure.Configuration.Tests/UnitTests/FeatureManagerServiceTests.cs
@@ -5,10 +5,7 @@ namespace Roo.Azure.Configuration.Tests.UnitTests
     public class FeatureManagerServiceTests
     {
         //Common
-        string featureName = "featureName";
-
-        [SetUp]
-        public void Setup() { }
+        private string featureName = "featureName";
 
         [Test]
         public async Task IsFeatureEnabled_Verify()

--- a/Roo.Azure.Configuration.Tests/UnitTests/HeaderMiddlewareTests.cs
+++ b/Roo.Azure.Configuration.Tests/UnitTests/HeaderMiddlewareTests.cs
@@ -8,8 +8,8 @@ namespace Roo.Azure.Configuration.Tests.UnitTests
     public class HeaderMiddlewareTests
     {
         //Common
-        Mock<IRooLogger> loggerMoq;
-        RequestDelegate next;
+        private Mock<IRooLogger> loggerMoq;
+        private RequestDelegate next;
 
         [SetUp]
         public void Setup()

--- a/Roo.Azure.Configuration.Tests/UnitTests/HeaderPropagateMiddlewareTests.cs
+++ b/Roo.Azure.Configuration.Tests/UnitTests/HeaderPropagateMiddlewareTests.cs
@@ -10,14 +10,14 @@ namespace Roo.Azure.Configuration.Tests.UnitTests
     public class HeaderPropagateMiddlewareTests
     {
         //Common
-        string sessionId = "sessionId";
-        string transactionId = "transactionId";
-        string channelId = "channelId";
-        string existingSessionId = "existingSessionId";
-        string existingTransactionId = "existingTransactionId";
-        string existingChannelId = "existingChannelId";
-        Mock<IConfiguration> configurationMoq;
-        Mock<IHeaderService> headerServiceMoq;
+        private string sessionId = "sessionId";
+        private string transactionId = "transactionId";
+        private string channelId = "channelId";
+        private string existingSessionId = "existingSessionId";
+        private string existingTransactionId = "existingTransactionId";
+        private string existingChannelId = "existingChannelId";
+        private Mock<IConfiguration> configurationMoq;
+        private Mock<IHeaderService> headerServiceMoq;
 
         [SetUp]
         public void Setup()

--- a/Roo.Azure.Configuration.Tests/UnitTests/HeaderServiceTests.cs
+++ b/Roo.Azure.Configuration.Tests/UnitTests/HeaderServiceTests.cs
@@ -7,11 +7,11 @@ namespace Roo.Azure.Configuration.Tests.UnitTests
     public class HeaderServiceTests
     {
         //Common
-        string sessionId = "sessionId";
-        string transactionId = "transactionId";
-        string channelId = "channelId";
-        UserInfo userInfo = new() { LoginId = "loginId", UserId = "userId", Email = "email", SubId = "subId", IsAuthenticated = true };
-        IHeaderDictionary headerDictionaryMissingHeaders;
+        private string sessionId = "sessionId";
+        private string transactionId = "transactionId";
+        private string channelId = "channelId";
+        private UserInfo userInfo = new() { LoginId = "loginId", UserId = "userId", Email = "email", SubId = "subId", IsAuthenticated = true };
+        private IHeaderDictionary headerDictionaryMissingHeaders;
 
         [SetUp]
         public void Setup()

--- a/Roo.Azure.Configuration.Tests/UnitTests/RedisServiceTests.cs
+++ b/Roo.Azure.Configuration.Tests/UnitTests/RedisServiceTests.cs
@@ -5,13 +5,12 @@ namespace Roo.Azure.Configuration.Tests.UnitTests
     public class RedisServiceTests
     {
         //Common
-        Mock<IConnectionMultiplexer> connectionMultiplexerMoq;
-        RedisService serviceConversion;
-        string key = "key";
-        string value = "value";
-        Test test;
-
-        TimeSpan expirationTime = new TimeSpan(0, 5, 0);
+        private Mock<IConnectionMultiplexer> connectionMultiplexerMoq;
+        private RedisService serviceConversion;
+        private string key = "key";
+        private string value = "value";
+        private Test test;
+        private TimeSpan expirationTime = new TimeSpan(0, 5, 0);
 
         [SetUp]
         public void Setup()

--- a/Roo.Azure.Configuration.Tests/UnitTests/RooHttpClientTests.cs
+++ b/Roo.Azure.Configuration.Tests/UnitTests/RooHttpClientTests.cs
@@ -1,0 +1,1742 @@
+using Azure.Core;
+using Azure.Identity;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Moq.Protected;
+using Newtonsoft.Json;
+using Roo.Azure.Configuration.Common.Http;
+using Roo.Azure.Configuration.Common.Http.AzureAdAuthentication;
+using Roo.Azure.Configuration.Common.Http.Models;
+using Roo.Azure.Configuration.Common.Logging;
+using Roo.Azure.Configuration.Common.Models;
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Roo.Azure.Configuration.Tests.UnitTests
+{
+    public class RooHttpClientTests
+    {
+        //Common
+        private Mock<IRooLogger> loggerMoq;
+        private Mock<IAzureAdClientAssertion> azureAdClientAssertionMoq;
+        private string sessionId = "sessionId";
+        private string transactionId = "transactionId";
+        private string channelId = "channelId";
+        private UserInfo userInfo = new() { LoginId = "loginId", UserId = "userId", Email = "email", SubId = "subId", IsAuthenticated = true };
+        private string httpClientName = "httpClientName";
+        private string relativeUrl = "http://unittest.com/test/";
+        private List<(string Parameter, string Value)> queryParameters = new() { ("parameter", "value") };
+        private string relativeUrlWithParameters = "http://unittest.com/test?parameter=value";
+        private string relativeUrlWithQueryObject = "http://unittest.com/test?Id=1&Value=value";
+        private Mock<ISession> session;
+        private Mock<ISession> sessionExistingSessionId;
+        private Test testObject = new() { Id = 1, Value = "value" };
+        private List<(string Name, string Value)> headers = new() { ("header", "value"), ("header2", "value2") };
+        private string token = "token";
+        private string authenticationHttpClientName = "authenticationHttpClientName";
+
+        [SetUp]
+        public void Setup()
+        {
+            loggerMoq = new();
+            azureAdClientAssertionMoq = new();
+            session = new();
+            var sessionStorage = new Dictionary<string, byte[]>();
+            session.Setup(x => x.Set(It.IsAny<string>(), It.IsAny<byte[]>())).Callback<string, byte[]>((key, value) => sessionStorage[key] = value);
+            session.Setup(x => x.TryGetValue(It.IsAny<string>(), out It.Ref<byte[]?>.IsAny)).Returns((string key, out byte[]? value) =>
+            {
+                if (sessionStorage.TryGetValue(key, out var storedValue))
+                {
+                    value = storedValue;
+                    return true;
+                }
+                value = null;
+                return false;
+            });
+            session.Object.SetString(Constants.SessionId, sessionId);
+            sessionExistingSessionId = new();
+            var sessionStorageExistingSessionId = new Dictionary<string, byte[]>();
+            sessionExistingSessionId.Setup(x => x.Set(It.IsAny<string>(), It.IsAny<byte[]>())).Callback<string, byte[]>((key, value) => sessionStorageExistingSessionId[key] = value);
+            sessionExistingSessionId.Setup(x => x.TryGetValue(It.IsAny<string>(), out It.Ref<byte[]?>.IsAny)).Returns((string key, out byte[]? value) =>
+            {
+                if (sessionStorageExistingSessionId.TryGetValue(key, out var storedValue))
+                {
+                    value = storedValue;
+                    return true;
+                }
+                value = null;
+                return false;
+            });
+            sessionExistingSessionId.Object.SetString(Constants.SessionId, "existingSessionId");
+        }
+
+        #region GetAsync
+        [Test]
+        public async Task GetAsyncNoDeserialization_Verify()
+        {
+            //Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Session = session.Object;
+            var claims = new List<Claim>
+            {
+                new Claim(Constants.UserInfoLoginId, "loginId")
+            };
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(claims));
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            var delegatingHandler = new Mock<DelegatingHandler>();
+            HttpRequestMessage? requestMessage = null;
+            delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessage = request).ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+            delegatingHandler.As<IDisposable>().Setup(x => x.Dispose());
+            var httpClient = new HttpClient(delegatingHandler.Object);
+            httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object);
+
+            //Act
+            var response = await service.GetAsync(relativeUrl, httpClientName, queryParameters);
+            if (requestMessage == null)
+            {
+                Assert.Fail("Request message is null.");
+                return;
+            }
+            requestMessage.Headers.TryGetValues(Constants.SessionIdHeaderName, out var sessionIdHeader);
+            requestMessage.Headers.TryGetValues(Constants.TransactionIdHeaderName, out var transactionIdHeader);
+            requestMessage.Headers.TryGetValues(Constants.ChannelIdHeaderName, out var channelIdHeader);
+            requestMessage.Headers.TryGetValues(Constants.UserInfoHeaderName, out var userInfoHeader);
+            var userInfoHeaderModel = JsonConvert.DeserializeObject<UserInfo>(userInfoHeader?.First() ?? default!);
+
+            //Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(sessionIdHeader, Is.Not.Null);
+                Assert.That(sessionIdHeader?.First(), Is.EqualTo(sessionId));
+                Assert.That(transactionIdHeader, Is.Not.Null);
+                Assert.That(transactionIdHeader?.First().Length, Is.EqualTo(32));
+                Assert.That(channelIdHeader, Is.Not.Null);
+                Assert.That(channelIdHeader?.First(), Is.EqualTo(channelId));
+                Assert.That(userInfoHeader, Is.Not.Null);
+                Assert.That(userInfoHeaderModel, Is.Not.Null);
+                Assert.That(userInfoHeaderModel?.LoginId, Is.EqualTo("loginId"));
+                Assert.That(requestMessage.RequestUri?.AbsoluteUri, Is.EqualTo(relativeUrlWithParameters));
+            });
+        }
+
+        [Test]
+        public async Task GetAsyncNoDeserializationQueryStringObject_Verify()
+        {
+            //Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Session = session.Object;
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            var delegatingHandler = new Mock<DelegatingHandler>();
+            HttpRequestMessage? requestMessage = null;
+            delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessage = request).ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+            delegatingHandler.As<IDisposable>().Setup(x => x.Dispose());
+            var httpClient = new HttpClient(delegatingHandler.Object);
+            httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object);
+
+            //Act
+            var response = await service.GetAsync(relativeUrl, httpClientName, testObject);
+            if (requestMessage == null)
+            {
+                Assert.Fail("Request message is null.");
+                return;
+            }
+
+            //Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(requestMessage.RequestUri?.AbsoluteUri, Is.EqualTo(relativeUrlWithQueryObject));
+            });
+        }
+
+        [Test]
+        public async Task GetAsyncQueryStringObject_Verify()
+        {
+            //Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Session = session.Object;
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            var delegatingHandler = new Mock<DelegatingHandler>();
+            HttpRequestMessage? requestMessage = null;
+            var httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonConvert.SerializeObject(testObject))
+            };
+            delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessage = request).ReturnsAsync(httpResponseMessage);
+            delegatingHandler.As<IDisposable>().Setup(x => x.Dispose());
+            var httpClient = new HttpClient(delegatingHandler.Object);
+            httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object);
+
+            //Act
+            var response = await service.GetAsync<Test>(relativeUrl, httpClientName, testObject);
+            if (requestMessage == null)
+            {
+                Assert.Fail("Request message is null.");
+                return;
+            }
+
+            //Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(requestMessage.RequestUri?.AbsoluteUri, Is.EqualTo(relativeUrlWithQueryObject));
+                Assert.That(response, Is.Not.Null);
+                Assert.That(response.Id, Is.EqualTo(testObject.Id));
+                Assert.That(response.Value, Is.EqualTo(testObject.Value));
+            });
+        }
+
+        [Test]
+        public async Task GetAsync_Verify()
+        {
+            //Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Session = session.Object;
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            var delegatingHandler = new Mock<DelegatingHandler>();
+            HttpRequestMessage? requestMessage = null;
+            var httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonConvert.SerializeObject(testObject))
+            };
+            delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessage = request).ReturnsAsync(httpResponseMessage);
+            delegatingHandler.As<IDisposable>().Setup(x => x.Dispose());
+            var httpClient = new HttpClient(delegatingHandler.Object);
+            httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object);
+
+            //Act
+            var response = await service.GetAsync<Test>(relativeUrl, httpClientName);
+            if (requestMessage == null)
+            {
+                Assert.Fail("Request message is null.");
+                return;
+            }
+
+            //Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(requestMessage.RequestUri?.AbsoluteUri, Is.EqualTo(relativeUrl));
+                Assert.That(response, Is.Not.Null);
+                Assert.That(response.Id, Is.EqualTo(testObject.Id));
+                Assert.That(response.Value, Is.EqualTo(testObject.Value));
+            });
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task GetAsyncEnumClientNames_Verify(bool deserialize)
+        {
+            //Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Session = session.Object;
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            var httpClientFactoryQueryObject = new Mock<IHttpClientFactory>();
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            var delegatingHandlerQueryObject = new Mock<DelegatingHandler>();
+            var delegatingHandler = new Mock<DelegatingHandler>();
+            HttpRequestMessage? requestMessageQueryObject = null;
+            HttpRequestMessage? requestMessage = null;
+            if (deserialize)
+            {
+                var httpResponseMessageQueryObject = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(JsonConvert.SerializeObject(testObject)) };
+                var httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(JsonConvert.SerializeObject(testObject)) };
+                delegatingHandlerQueryObject.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessageQueryObject = request).ReturnsAsync(httpResponseMessageQueryObject);
+                delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessage = request).ReturnsAsync(httpResponseMessage);
+            }
+            else
+            {
+                delegatingHandlerQueryObject.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessageQueryObject = request).ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+                delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessage = request).ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+            }
+            delegatingHandlerQueryObject.As<IDisposable>().Setup(x => x.Dispose());
+            delegatingHandler.As<IDisposable>().Setup(x => x.Dispose());
+            var httpClientQueryObject = new HttpClient(delegatingHandlerQueryObject.Object);
+            var httpClient = new HttpClient(delegatingHandler.Object);
+            httpClientFactoryQueryObject.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClientQueryObject);
+            httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var serviceQueryObject = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactoryQueryObject.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object);
+            var service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object);
+
+            //Act
+            HttpResponseMessage? responseQueryObjectMessage = null;
+            HttpResponseMessage? responseMessage = null;
+            Test? responseQueryObject = null;
+            Test? response = null;
+            if (deserialize)
+            {
+                responseQueryObject = await serviceQueryObject.GetAsync<Test>(relativeUrl, TestClientName.httpClientName, testObject);
+                response = await service.GetAsync<Test>(relativeUrl, TestClientName.httpClientName);
+            }
+            else
+            {
+                responseQueryObjectMessage = await serviceQueryObject.GetAsync(relativeUrl, TestClientName.httpClientName, testObject);
+                responseMessage = await service.GetAsync(relativeUrl, TestClientName.httpClientName);
+            }
+            if (requestMessage == null || requestMessageQueryObject == null)
+            {
+                Assert.Fail("Request message is null.");
+                return;
+            }
+
+            //Assert
+            Assert.Multiple(() =>
+            {
+                if (deserialize)
+                {
+                    Assert.That(requestMessageQueryObject.RequestUri?.AbsoluteUri, Is.EqualTo(relativeUrlWithQueryObject));
+                    Assert.That(requestMessage.RequestUri?.AbsoluteUri, Is.EqualTo(relativeUrl));
+                    Assert.That(responseQueryObject, Is.Not.Null);
+                    Assert.That(responseQueryObject?.Id, Is.EqualTo(testObject.Id));
+                    Assert.That(responseQueryObject?.Value, Is.EqualTo(testObject.Value));
+                    Assert.That(response, Is.Not.Null);
+                    Assert.That(response?.Id, Is.EqualTo(testObject.Id));
+                    Assert.That(response?.Value, Is.EqualTo(testObject.Value));
+                }
+                else
+                {
+                    Assert.That(requestMessageQueryObject.RequestUri?.AbsoluteUri, Is.EqualTo(relativeUrlWithQueryObject));
+                    Assert.That(requestMessage.RequestUri?.AbsoluteUri, Is.EqualTo(relativeUrl));
+                }
+            });
+        }
+        #endregion
+
+        #region PostAsync
+        [Test]
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(3)]
+        public async Task PostAsyncNoDeserialization_Verify(int inputModelType)
+        {
+            //Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Session = session.Object;
+            var claims = new List<Claim>
+            {
+                new Claim(Constants.UserInfoLoginId, "loginId")
+            };
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(claims));
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            var delegatingHandler = new Mock<DelegatingHandler>();
+            HttpRequestMessage? requestMessage = null;
+            delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessage = request).ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+            delegatingHandler.As<IDisposable>().Setup(x => x.Dispose());
+            var httpClient = new HttpClient(delegatingHandler.Object);
+            httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object);
+
+            //Act
+            HttpResponseMessage? response = null;
+            if (inputModelType == 0)
+            {
+                response = await service.PostAsync(relativeUrl, httpClientName, testObject, queryParameters);
+            }
+            else if (inputModelType == 1)
+            {
+                var httpContent = new StringContent(JsonConvert.SerializeObject(testObject));
+                response = await service.PostAsync(relativeUrl, httpClientName, httpContent, queryParameters);
+            }
+            else if (inputModelType == 2)
+            {
+                var multipartFormDataContent = new MultipartFormDataContent
+                {
+                    new StringContent(JsonConvert.SerializeObject(testObject))
+                };
+                var responses = await service.PostAsync(relativeUrl, httpClientName, multipartFormDataContent, queryParameters);
+            }
+            else if (inputModelType == 3)
+            {
+                var multipartContent = new MultipartContent();
+                response = await service.PostAsync(relativeUrl, httpClientName, multipartContent, queryParameters);
+            }
+            if (requestMessage == null)
+            {
+                Assert.Fail("Request message is null.");
+                return;
+            }
+            requestMessage.Headers.TryGetValues(Constants.SessionIdHeaderName, out var sessionIdHeader);
+            requestMessage.Headers.TryGetValues(Constants.TransactionIdHeaderName, out var transactionIdHeader);
+            requestMessage.Headers.TryGetValues(Constants.ChannelIdHeaderName, out var channelIdHeader);
+            requestMessage.Headers.TryGetValues(Constants.UserInfoHeaderName, out var userInfoHeader);
+            var userInfoHeaderModel = JsonConvert.DeserializeObject<UserInfo>(userInfoHeader?.First() ?? default!);
+            Test? requestObject = null;
+            if (inputModelType < 2)
+            {
+                using (var json = new JsonTextReader(new StreamReader(await requestMessage.Content!.SafeReadAsStreamAsync().ConfigureAwait(false) ?? default!)))
+                {
+                    var serializer = JsonSerializer.Create();
+                    requestObject = serializer.Deserialize<Test>(json);
+                }
+            }
+
+            //Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(sessionIdHeader, Is.Not.Null);
+                Assert.That(sessionIdHeader?.First(), Is.EqualTo(sessionId));
+                Assert.That(transactionIdHeader, Is.Not.Null);
+                Assert.That(transactionIdHeader?.First().Length, Is.EqualTo(32));
+                Assert.That(channelIdHeader, Is.Not.Null);
+                Assert.That(channelIdHeader?.First(), Is.EqualTo(channelId));
+                Assert.That(userInfoHeader, Is.Not.Null);
+                Assert.That(userInfoHeaderModel, Is.Not.Null);
+                Assert.That(userInfoHeaderModel?.LoginId, Is.EqualTo("loginId"));
+                Assert.That(requestMessage.RequestUri?.AbsoluteUri, Is.EqualTo(relativeUrlWithParameters));
+                if (inputModelType < 2)
+                {
+                    Assert.That(requestObject?.Id, Is.EqualTo(testObject.Id));
+                    Assert.That(requestObject?.Value, Is.EqualTo(testObject.Value));
+                }
+            });
+        }
+
+        [Test]
+        public async Task PostAsync_Verify()
+        {
+            //Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Session = session.Object;
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            var delegatingHandler = new Mock<DelegatingHandler>();
+            HttpRequestMessage? requestMessage = null;
+            var httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonConvert.SerializeObject(testObject))
+            };
+            delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessage = request).ReturnsAsync(httpResponseMessage);
+            delegatingHandler.As<IDisposable>().Setup(x => x.Dispose());
+            var httpClient = new HttpClient(delegatingHandler.Object);
+            httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object);
+
+            //Act
+            var response = await service.PostAsync<Test>(relativeUrl, httpClientName, testObject);
+            if (requestMessage == null)
+            {
+                Assert.Fail("Request message is null.");
+                return;
+            }
+            Test? requestObject = null;
+            using (var json = new JsonTextReader(new StreamReader(await requestMessage.Content!.SafeReadAsStreamAsync().ConfigureAwait(false) ?? default!)))
+            {
+                var serializer = JsonSerializer.Create();
+                requestObject = serializer.Deserialize<Test>(json);
+            }
+
+            //Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(requestMessage.RequestUri?.AbsoluteUri, Is.EqualTo(relativeUrl));
+                Assert.That(response, Is.Not.Null);
+                Assert.That(response.Id, Is.EqualTo(testObject.Id));
+                Assert.That(response.Value, Is.EqualTo(testObject.Value));
+                Assert.That(requestObject?.Id, Is.EqualTo(testObject.Id));
+                Assert.That(requestObject?.Value, Is.EqualTo(testObject.Value));
+            });
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task PostAsyncEnumClientNames_Verify(bool deserialize)
+        {
+            //Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Session = session.Object;
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            var delegatingHandler = new Mock<DelegatingHandler>();
+            HttpRequestMessage? requestMessage = null;
+            if (deserialize)
+            {
+                var httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(JsonConvert.SerializeObject(testObject)) };
+                delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessage = request).ReturnsAsync(httpResponseMessage);
+            }
+            else
+            {
+                delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessage = request).ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+            }
+            delegatingHandler.As<IDisposable>().Setup(x => x.Dispose());
+            var httpClient = new HttpClient(delegatingHandler.Object);
+            httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object);
+
+            //Act
+            HttpResponseMessage? responseMessage = null;
+            Test? response = null;
+            if (deserialize)
+            {
+                response = await service.PostAsync<Test>(relativeUrl, TestClientName.httpClientName, testObject);
+            }
+            else
+            {
+                responseMessage = await service.PostAsync(relativeUrl, TestClientName.httpClientName, testObject);
+            }
+            if (requestMessage == null)
+            {
+                Assert.Fail("Request message is null.");
+                return;
+            }
+
+            //Assert
+            Assert.Multiple(() =>
+            {
+                if (deserialize)
+                {
+                    Assert.That(requestMessage.RequestUri?.AbsoluteUri, Is.EqualTo(relativeUrl));
+                    Assert.That(response, Is.Not.Null);
+                    Assert.That(response?.Id, Is.EqualTo(testObject.Id));
+                    Assert.That(response?.Value, Is.EqualTo(testObject.Value));
+                }
+                else
+                {
+                    Assert.That(requestMessage.RequestUri?.AbsoluteUri, Is.EqualTo(relativeUrl));
+                }
+            });
+        }
+        #endregion
+
+        #region PutAsync
+        [Test]
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(3)]
+        public async Task PutAsyncNoDeserialization_Verify(int inputModelType)
+        {
+            //Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Session = session.Object;
+            var claims = new List<Claim>
+            {
+                new Claim(Constants.UserInfoLoginId, "loginId")
+            };
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(claims));
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            var delegatingHandler = new Mock<DelegatingHandler>();
+            HttpRequestMessage? requestMessage = null;
+            delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessage = request).ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+            delegatingHandler.As<IDisposable>().Setup(x => x.Dispose());
+            var httpClient = new HttpClient(delegatingHandler.Object);
+            httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object);
+
+            //Act
+            HttpResponseMessage? response = null;
+            if (inputModelType == 0)
+            {
+                response = await service.PutAsync(relativeUrl, httpClientName, testObject, queryParameters);
+            }
+            else if (inputModelType == 1)
+            {
+                var httpContent = new StringContent(JsonConvert.SerializeObject(testObject));
+                response = await service.PutAsync(relativeUrl, httpClientName, httpContent, queryParameters);
+            }
+            else if (inputModelType == 2)
+            {
+                var multipartFormDataContent = new MultipartFormDataContent
+                {
+                    new StringContent(JsonConvert.SerializeObject(testObject))
+                };
+                var responses = await service.PutAsync(relativeUrl, httpClientName, multipartFormDataContent, queryParameters);
+            }
+            else if (inputModelType == 3)
+            {
+                var multipartContent = new MultipartContent();
+                response = await service.PutAsync(relativeUrl, httpClientName, multipartContent, queryParameters);
+            }
+            if (requestMessage == null)
+            {
+                Assert.Fail("Request message is null.");
+                return;
+            }
+            requestMessage.Headers.TryGetValues(Constants.SessionIdHeaderName, out var sessionIdHeader);
+            requestMessage.Headers.TryGetValues(Constants.TransactionIdHeaderName, out var transactionIdHeader);
+            requestMessage.Headers.TryGetValues(Constants.ChannelIdHeaderName, out var channelIdHeader);
+            requestMessage.Headers.TryGetValues(Constants.UserInfoHeaderName, out var userInfoHeader);
+            var userInfoHeaderModel = JsonConvert.DeserializeObject<UserInfo>(userInfoHeader?.First() ?? default!);
+            Test? requestObject = null;
+            if (inputModelType < 2)
+            {
+                using (var json = new JsonTextReader(new StreamReader(await requestMessage.Content!.SafeReadAsStreamAsync().ConfigureAwait(false) ?? default!)))
+                {
+                    var serializer = JsonSerializer.Create();
+                    requestObject = serializer.Deserialize<Test>(json);
+                }
+            }
+
+            //Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(sessionIdHeader, Is.Not.Null);
+                Assert.That(sessionIdHeader?.First(), Is.EqualTo(sessionId));
+                Assert.That(transactionIdHeader, Is.Not.Null);
+                Assert.That(transactionIdHeader?.First().Length, Is.EqualTo(32));
+                Assert.That(channelIdHeader, Is.Not.Null);
+                Assert.That(channelIdHeader?.First(), Is.EqualTo(channelId));
+                Assert.That(userInfoHeader, Is.Not.Null);
+                Assert.That(userInfoHeaderModel, Is.Not.Null);
+                Assert.That(userInfoHeaderModel?.LoginId, Is.EqualTo("loginId"));
+                Assert.That(requestMessage.RequestUri?.AbsoluteUri, Is.EqualTo(relativeUrlWithParameters));
+                if (inputModelType < 2)
+                {
+                    Assert.That(requestObject?.Id, Is.EqualTo(testObject.Id));
+                    Assert.That(requestObject?.Value, Is.EqualTo(testObject.Value));
+                }
+            });
+        }
+
+        [Test]
+        public async Task PutAsync_Verify()
+        {
+            //Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Session = session.Object;
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            var delegatingHandler = new Mock<DelegatingHandler>();
+            HttpRequestMessage? requestMessage = null;
+            var httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonConvert.SerializeObject(testObject))
+            };
+            delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessage = request).ReturnsAsync(httpResponseMessage);
+            delegatingHandler.As<IDisposable>().Setup(x => x.Dispose());
+            var httpClient = new HttpClient(delegatingHandler.Object);
+            httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object);
+
+            //Act
+            var response = await service.PutAsync<Test>(relativeUrl, httpClientName, testObject);
+            if (requestMessage == null)
+            {
+                Assert.Fail("Request message is null.");
+                return;
+            }
+            Test? requestObject = null;
+            using (var json = new JsonTextReader(new StreamReader(await requestMessage.Content!.SafeReadAsStreamAsync().ConfigureAwait(false) ?? default!)))
+            {
+                var serializer = JsonSerializer.Create();
+                requestObject = serializer.Deserialize<Test>(json);
+            }
+
+            //Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(requestMessage.RequestUri?.AbsoluteUri, Is.EqualTo(relativeUrl));
+                Assert.That(response, Is.Not.Null);
+                Assert.That(response.Id, Is.EqualTo(testObject.Id));
+                Assert.That(response.Value, Is.EqualTo(testObject.Value));
+                Assert.That(requestObject?.Id, Is.EqualTo(testObject.Id));
+                Assert.That(requestObject?.Value, Is.EqualTo(testObject.Value));
+            });
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task PutAsyncEnumClientNames_Verify(bool deserialize)
+        {
+            //Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Session = session.Object;
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            var delegatingHandler = new Mock<DelegatingHandler>();
+            HttpRequestMessage? requestMessage = null;
+            if (deserialize)
+            {
+                var httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(JsonConvert.SerializeObject(testObject)) };
+                delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessage = request).ReturnsAsync(httpResponseMessage);
+            }
+            else
+            {
+                delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessage = request).ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+            }
+            delegatingHandler.As<IDisposable>().Setup(x => x.Dispose());
+            var httpClient = new HttpClient(delegatingHandler.Object);
+            httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object);
+
+            //Act
+            HttpResponseMessage? responseMessage = null;
+            Test? response = null;
+            if (deserialize)
+            {
+                response = await service.PutAsync<Test>(relativeUrl, TestClientName.httpClientName, testObject);
+            }
+            else
+            {
+                responseMessage = await service.PutAsync(relativeUrl, TestClientName.httpClientName, testObject);
+            }
+            if (requestMessage == null)
+            {
+                Assert.Fail("Request message is null.");
+                return;
+            }
+
+            //Assert
+            Assert.Multiple(() =>
+            {
+                if (deserialize)
+                {
+                    Assert.That(requestMessage.RequestUri?.AbsoluteUri, Is.EqualTo(relativeUrl));
+                    Assert.That(response, Is.Not.Null);
+                    Assert.That(response?.Id, Is.EqualTo(testObject.Id));
+                    Assert.That(response?.Value, Is.EqualTo(testObject.Value));
+                }
+                else
+                {
+                    Assert.That(requestMessage.RequestUri?.AbsoluteUri, Is.EqualTo(relativeUrl));
+                }
+            });
+        }
+        #endregion
+
+        #region DeleteAsync
+        [Test]
+        public async Task DeleteAsyncNoDeserialization_Verify()
+        {
+            //Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Session = session.Object;
+            var claims = new List<Claim>
+            {
+                new Claim(Constants.UserInfoLoginId, "loginId")
+            };
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(claims));
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            var delegatingHandler = new Mock<DelegatingHandler>();
+            HttpRequestMessage? requestMessage = null;
+            delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessage = request).ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+            delegatingHandler.As<IDisposable>().Setup(x => x.Dispose());
+            var httpClient = new HttpClient(delegatingHandler.Object);
+            httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object);
+
+            //Act
+            var response = await service.DeleteAsync(relativeUrl, httpClientName, queryParameters);
+            if (requestMessage == null)
+            {
+                Assert.Fail("Request message is null.");
+                return;
+            }
+            requestMessage.Headers.TryGetValues(Constants.SessionIdHeaderName, out var sessionIdHeader);
+            requestMessage.Headers.TryGetValues(Constants.TransactionIdHeaderName, out var transactionIdHeader);
+            requestMessage.Headers.TryGetValues(Constants.ChannelIdHeaderName, out var channelIdHeader);
+            requestMessage.Headers.TryGetValues(Constants.UserInfoHeaderName, out var userInfoHeader);
+            var userInfoHeaderModel = JsonConvert.DeserializeObject<UserInfo>(userInfoHeader?.First() ?? default!);
+
+            //Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(sessionIdHeader, Is.Not.Null);
+                Assert.That(sessionIdHeader?.First(), Is.EqualTo(sessionId));
+                Assert.That(transactionIdHeader, Is.Not.Null);
+                Assert.That(transactionIdHeader?.First().Length, Is.EqualTo(32));
+                Assert.That(channelIdHeader, Is.Not.Null);
+                Assert.That(channelIdHeader?.First(), Is.EqualTo(channelId));
+                Assert.That(userInfoHeader, Is.Not.Null);
+                Assert.That(userInfoHeaderModel, Is.Not.Null);
+                Assert.That(userInfoHeaderModel?.LoginId, Is.EqualTo("loginId"));
+                Assert.That(requestMessage.RequestUri?.AbsoluteUri, Is.EqualTo(relativeUrlWithParameters));
+            });
+        }
+
+        [Test]
+        public async Task DeleteAsync_Verify()
+        {
+            //Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Session = session.Object;
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            var delegatingHandler = new Mock<DelegatingHandler>();
+            HttpRequestMessage? requestMessage = null;
+            var httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonConvert.SerializeObject(testObject))
+            };
+            delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessage = request).ReturnsAsync(httpResponseMessage);
+            delegatingHandler.As<IDisposable>().Setup(x => x.Dispose());
+            var httpClient = new HttpClient(delegatingHandler.Object);
+            httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object);
+
+            //Act
+            var response = await service.DeleteAsync<Test>(relativeUrl, httpClientName);
+            if (requestMessage == null)
+            {
+                Assert.Fail("Request message is null.");
+                return;
+            }
+
+            //Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(requestMessage.RequestUri?.AbsoluteUri, Is.EqualTo(relativeUrl));
+                Assert.That(response, Is.Not.Null);
+                Assert.That(response.Id, Is.EqualTo(testObject.Id));
+                Assert.That(response.Value, Is.EqualTo(testObject.Value));
+            });
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task DeleteAsyncEnumClientNames_Verify(bool deserialize)
+        {
+            //Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Session = session.Object;
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            var delegatingHandler = new Mock<DelegatingHandler>();
+            HttpRequestMessage? requestMessage = null;
+            if (deserialize)
+            {
+                var httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(JsonConvert.SerializeObject(testObject)) };
+                delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessage = request).ReturnsAsync(httpResponseMessage);
+            }
+            else
+            {
+                delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessage = request).ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+            }
+            delegatingHandler.As<IDisposable>().Setup(x => x.Dispose());
+            var httpClient = new HttpClient(delegatingHandler.Object);
+            httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object);
+
+            //Act
+            HttpResponseMessage? responseMessage = null;
+            Test? response = null;
+            if (deserialize)
+            {
+                response = await service.DeleteAsync<Test>(relativeUrl, TestClientName.httpClientName);
+            }
+            else
+            {
+                responseMessage = await service.DeleteAsync(relativeUrl, TestClientName.httpClientName);
+            }
+            if (requestMessage == null)
+            {
+                Assert.Fail("Request message is null.");
+                return;
+            }
+
+            //Assert
+            Assert.Multiple(() =>
+            {
+                if (deserialize)
+                {
+                    Assert.That(requestMessage.RequestUri?.AbsoluteUri, Is.EqualTo(relativeUrl));
+                    Assert.That(response, Is.Not.Null);
+                    Assert.That(response?.Id, Is.EqualTo(testObject.Id));
+                    Assert.That(response?.Value, Is.EqualTo(testObject.Value));
+                }
+                else
+                {
+                    Assert.That(requestMessage.RequestUri?.AbsoluteUri, Is.EqualTo(relativeUrl));
+                }
+            });
+        }
+        #endregion
+
+        #region HeaderParameters
+        [Test]
+        [TestCase(false)]
+        [TestCase(true)]
+        public async Task AddHeadersFromIncomingRequest_Verify(bool directlySetHeaders)
+        {
+            //Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers.TryAdd(Constants.SessionIdHeaderName, sessionId);
+            httpContext.Request.Headers.TryAdd(Constants.TransactionIdHeaderName, "existingTransactionId");
+            httpContext.Request.Headers.TryAdd(Constants.ChannelIdHeaderName, "existingChannelId");
+            httpContext.Request.Headers.TryAdd(Constants.UserInfoHeaderName, JsonConvert.SerializeObject(userInfo));
+            httpContext.Session = sessionExistingSessionId.Object;
+            var claims = new List<Claim>
+            {
+                new Claim(Constants.UserInfoLoginId, "loginId"),
+                new Claim(ClaimTypes.Email, "email")
+            };
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(claims));
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            var delegatingHandler = new Mock<DelegatingHandler>();
+            HttpRequestMessage? requestMessage = null;
+            delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessage = request).ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+            delegatingHandler.As<IDisposable>().Setup(x => x.Dispose());
+            var httpClient = new HttpClient(delegatingHandler.Object);
+            httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object);
+            if (directlySetHeaders)
+            {
+                service.SessionId = $"{sessionId}2";
+                service.TransactionId = transactionId;
+                service.ChannelId = $"{channelId}2";
+                service.UserInfo = new() { LoginId = "loginId2", UserId = "userId2", Email = "email2", SubId = "subId2", IsAuthenticated = true };
+            }
+
+            //Act
+            var response = await service.GetAsync(relativeUrl, httpClientName);
+            if (requestMessage == null)
+            {
+                Assert.Fail("Request message is null.");
+                return;
+            }
+            requestMessage.Headers.TryGetValues(Constants.SessionIdHeaderName, out var sessionIdHeader);
+            requestMessage.Headers.TryGetValues(Constants.TransactionIdHeaderName, out var transactionIdHeader);
+            requestMessage.Headers.TryGetValues(Constants.ChannelIdHeaderName, out var channelIdHeader);
+            requestMessage.Headers.TryGetValues(Constants.UserInfoHeaderName, out var userInfoHeader);
+            var userInfoHeaderModel = JsonConvert.DeserializeObject<UserInfo>(userInfoHeader?.First() ?? default!);
+
+            //Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(sessionIdHeader, Is.Not.Null);
+                Assert.That(transactionIdHeader, Is.Not.Null);
+                Assert.That(transactionIdHeader?.First(), Is.Not.EqualTo("existingTransactionId"));
+                Assert.That(channelIdHeader, Is.Not.Null);
+                Assert.That(userInfoHeader, Is.Not.Null);
+                Assert.That(userInfoHeaderModel, Is.Not.Null);
+                Assert.That(userInfoHeaderModel?.IsAuthenticated, Is.EqualTo(true));
+
+                if (!directlySetHeaders)
+                {
+                    Assert.That(sessionIdHeader?.First(), Is.EqualTo(sessionId));
+                    Assert.That(transactionIdHeader?.First().Length, Is.EqualTo(32));
+                    Assert.That(channelIdHeader?.First(), Is.EqualTo(channelId));
+                    Assert.That(userInfoHeaderModel?.LoginId, Is.EqualTo("loginId"));
+                    Assert.That(userInfoHeaderModel?.UserId, Is.EqualTo("userId"));
+                    Assert.That(userInfoHeaderModel?.Email, Is.EqualTo("email"));
+                    Assert.That(userInfoHeaderModel?.SubId, Is.EqualTo("subId"));
+                }
+                else
+                {
+                    Assert.That(sessionIdHeader?.First(), Is.EqualTo($"{sessionId}2"));
+                    Assert.That(transactionIdHeader?.First(), Is.EqualTo(transactionId));
+                    Assert.That(channelIdHeader?.First(), Is.EqualTo($"{channelId}2"));
+                    Assert.That(userInfoHeaderModel?.LoginId, Is.EqualTo("loginId2"));
+                    Assert.That(userInfoHeaderModel?.UserId, Is.EqualTo("userId2"));
+                    Assert.That(userInfoHeaderModel?.Email, Is.EqualTo("email2"));
+                    Assert.That(userInfoHeaderModel?.SubId, Is.EqualTo("subId2"));
+                }
+            });
+        }
+
+        [Test]
+        [TestCase(false)]
+        [TestCase(true)]
+        public async Task AddHeadersForAuthentication_Verify(bool addApimHeader)
+        {
+            //Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Session = session.Object;
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            var delegatingHandler = new Mock<DelegatingHandler>();
+            HttpRequestMessage? requestMessage = null;
+            delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessage = request).ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+            delegatingHandler.As<IDisposable>().Setup(x => x.Dispose());
+            var httpClient = new HttpClient(delegatingHandler.Object);
+            httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object);
+            service.AuthenticationInfo = new()
+            {
+                AdditionalRequestHeaders = headers,
+                AuthenticationStrategy = AuthenticationStrategy.OAuth
+            };
+            if (addApimHeader)
+            {
+                service.AuthenticationInfo.AuthenticationStrategy = AuthenticationStrategy.ApimCertificate;
+                service.AuthenticationInfo.ApimSubscriptionKey = "apimSubscriptionKey";
+            }
+
+            //Act
+            var response = await service.GetAsync(relativeUrl, httpClientName);
+            if (requestMessage == null)
+            {
+                Assert.Fail("Request message is null.");
+                return;
+            }
+            requestMessage.Headers.TryGetValues(headers[0].Name, out var authHeader);
+            requestMessage.Headers.TryGetValues(headers[1].Name, out var authHeader2);
+            requestMessage.Headers.TryGetValues("Ocp-Apim-Subscription-Key", out var apimHeader);
+
+            //Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(authHeader, Is.Not.Null);
+                Assert.That(authHeader?.First(), Is.EqualTo(headers[0].Value));
+                Assert.That(authHeader2, Is.Not.Null);
+                Assert.That(authHeader2?.First(), Is.EqualTo(headers[1].Value));
+
+                if (!addApimHeader)
+                {
+                    Assert.That(apimHeader, Is.Null);
+                }
+                else
+                {
+                    Assert.That(apimHeader?.First(), Is.EqualTo("apimSubscriptionKey"));
+                }
+            });
+        }
+        #endregion
+
+        #region GetToken
+        [Test]
+        [TestCase("none", true)]
+        [TestCase("none", false)]
+        [TestCase("redis", true)]
+        [TestCase("redis", false)]
+        [TestCase("memoryCache", true)]
+        [TestCase("memoryCache", false)]
+        public async Task GetOAuthToken_Verify(string tokenStorage, bool tokenReturned)
+        {
+            //Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Session = session.Object;
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            var delegatingHandler = new Mock<DelegatingHandler>();
+            var delegatingHandlerAuth = new Mock<DelegatingHandler>();
+            HttpRequestMessage? requestMessage = null;
+            HttpRequestMessage? requestMessageAuth = null;
+            delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessage = request).ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+            var tokenResponse = new OAuthTokenResponse()
+            {
+                Access_Token = token,
+                Expires_In = 61,
+                RefreshToken = "refreshToken",
+                Token_Type = "tokenType"
+            };
+            var httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(tokenResponse)
+            };
+            if (tokenReturned)
+            {
+                delegatingHandlerAuth.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessageAuth = request).ReturnsAsync(httpResponseMessage);
+            }
+            else
+            {
+                delegatingHandlerAuth.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessageAuth = request).ReturnsAsync(new HttpResponseMessage(HttpStatusCode.NotFound));
+            }
+            delegatingHandler.As<IDisposable>().Setup(x => x.Dispose());
+            delegatingHandlerAuth.As<IDisposable>().Setup(x => x.Dispose());
+            var httpClient = new HttpClient(delegatingHandler.Object);
+            var httpClientAuth = new HttpClient(delegatingHandlerAuth.Object);
+            httpClientFactory.Setup(x => x.CreateClient(httpClientName)).Returns(httpClient);
+            httpClientFactory.Setup(x => x.CreateClient(authenticationHttpClientName)).Returns(httpClientAuth);
+            RooHttpClient service = default!;
+            Mock<IRedisService>? redis = null;
+            MemoryCache? memoryCache = null;
+            if (tokenStorage.Equals("none"))
+            {
+                service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object);
+            }
+            else if (tokenStorage.Equals("redis"))
+            {
+                redis = new Mock<IRedisService>();
+                redis.Setup(x => x.Get(It.IsAny<string>())).ReturnsAsync((string?)null);
+                redis.Setup(x => x.Set(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan>())).ReturnsAsync(true);
+                service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object, redis.Object);
+            }
+            else if (tokenStorage.Equals("memoryCache"))
+            {
+                memoryCache = new MemoryCache(new MemoryCacheOptions());
+                service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object, memoryCache);
+            }
+            service.AuthenticationInfo = new()
+            {
+                AuthenticationStrategy = AuthenticationStrategy.OAuth,
+                AuthenticationHttpClientName = authenticationHttpClientName,
+                LoginId = "loginId",
+                Password = "password",
+                TokenUrl = "http://unittest.com/test/auth",
+                AuthenticationHeaders  = headers
+            };
+
+            //Act
+            var response = await service.GetAsync(relativeUrl, httpClientName);
+            if (requestMessage == null || requestMessageAuth == null)
+            {
+                Assert.Fail("Request message is null.");
+                return;
+            }
+            requestMessage.Headers.TryGetValues("Authorization", out var authorizationHeader);
+            IEnumerable<string>? contentTypeHeader = null;
+            requestMessageAuth.Content?.Headers.TryGetValues("Content-Type", out contentTypeHeader);
+            var requestAuthContent = await requestMessageAuth.Content.ReadAsFormDataAsync();
+
+            //Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(contentTypeHeader, Is.Not.Null);
+                Assert.That(contentTypeHeader?.First(), Is.EqualTo("application/x-www-form-urlencoded"));
+                Assert.That(requestAuthContent, Is.Not.Null);
+                Assert.That(requestAuthContent["username"], Is.Not.Null);
+                Assert.That(requestAuthContent["username"], Is.EqualTo("loginId"));
+                Assert.That(requestAuthContent["password"], Is.Not.Null);
+                Assert.That(requestAuthContent["password"], Is.EqualTo("password"));
+                Assert.That(requestAuthContent["grant_type"], Is.Not.Null);
+                Assert.That(requestAuthContent["grant_type"], Is.EqualTo("password"));
+                if (tokenReturned)
+                {
+                    Assert.That(authorizationHeader, Is.Not.Null);
+                    Assert.That(authorizationHeader?.First(), Is.EqualTo($"Bearer {token}"));
+                    if (tokenStorage.Equals("redis"))
+                    {
+                        redis?.Verify(x => x.Get(It.IsAny<string>()), Times.Once);
+                        redis?.Verify(x => x.Set(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>()), Times.Once);
+                    }
+                    else if (tokenStorage.Equals("memoryCache"))
+                    {
+                        Assert.That(memoryCache?.Get(httpClientName), Is.EqualTo(token));
+                    }
+                }
+                else
+                {
+                    Assert.That(authorizationHeader, Is.Null);
+                    if (tokenStorage.Equals("redis"))
+                    {
+                        redis?.Verify(x => x.Get(It.IsAny<string>()), Times.Once);
+                        redis?.Verify(x => x.Set(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>()), Times.Never);
+                    }
+                    else if (tokenStorage.Equals("memoryCache"))
+                    {
+                        Assert.That(memoryCache?.Get(httpClientName), Is.Null);
+                    }
+                }
+                
+            });
+            if (memoryCache != null)
+            {
+                memoryCache?.Dispose();
+            }
+        }
+
+        [Test]
+        [TestCase("certKeyVault", "none", true)]
+        [TestCase("certKeyVault", "none", false)]
+        [TestCase("certKeyVault", "redis", true)]
+        [TestCase("certKeyVault", "redis", false)]
+        [TestCase("certKeyVault", "memoryCache", true)]
+        [TestCase("certKeyVault", "memoryCache", false)]
+        [TestCase("certPassedIn", "none", true)]
+        [TestCase("certGenerateFromString", "none", true)]
+        [TestCase("clientSecret", "none", true)]
+        public async Task GetApimCertificateToken_Verify(string apimAuth, string tokenStorage, bool tokenReturned)
+        {
+            //Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Session = session.Object;
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            var delegatingHandler = new Mock<DelegatingHandler>();
+            HttpRequestMessage? requestMessage = null;
+            delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessage = request).ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+            delegatingHandler.As<IDisposable>().Setup(x => x.Dispose());
+            var httpClient = new HttpClient(delegatingHandler.Object);
+            httpClientFactory.Setup(x => x.CreateClient(httpClientName)).Returns(httpClient);
+            var azureAdClientAssertion = new Mock<IAzureAdClientAssertion>();
+            if (apimAuth.Equals("certKeyVault"))
+            {
+                azureAdClientAssertion.Setup(x => x.GetCertificateFromKeyVault(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TokenCredential?>())).ReturnsAsync(new Mock<X509Certificate2>().Object);
+            }
+            else if (apimAuth.Equals("certGenerateFromString"))
+            {
+                azureAdClientAssertion.Setup(x => x.GenerateCertificateFromString(It.IsAny<string>(), It.IsAny<string>())).Returns(new Mock<X509Certificate2>().Object);
+            }
+            if (!apimAuth.Equals("clientSecret"))
+            {
+                if (tokenReturned)
+                {
+                    azureAdClientAssertion.Setup(x => x.GetTokenAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<X509Certificate2>(), It.IsAny<string>())).ReturnsAsync(token);
+                }
+                else
+                {
+                    azureAdClientAssertion.Setup(x => x.GetTokenAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<X509Certificate2>(), It.IsAny<string>())).ReturnsAsync((string?)null);
+                }
+            }
+            else
+            {
+                if (tokenReturned)
+                {
+                    azureAdClientAssertion.Setup(x => x.GetTokenAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(token);
+                }
+                else
+                {
+                    azureAdClientAssertion.Setup(x => x.GetTokenAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync((string?)null);
+                }
+            }
+            RooHttpClient service = default!;
+            Mock<IRedisService>? redis = null;
+            MemoryCache? memoryCache = null;
+            if (tokenStorage.Equals("none"))
+            {
+                service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertion.Object);
+            }
+            else if (tokenStorage.Equals("redis"))
+            {
+                redis = new Mock<IRedisService>();
+                redis.Setup(x => x.Get(It.IsAny<string>())).ReturnsAsync((string?)null);
+                redis.Setup(x => x.Set(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan>())).ReturnsAsync(true);
+                service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertion.Object, redis.Object);
+            }
+            else if (tokenStorage.Equals("memoryCache"))
+            {
+                memoryCache = new MemoryCache(new MemoryCacheOptions());
+                service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertion.Object, memoryCache);
+            }
+            service.AuthenticationInfo = new()
+            {
+                AuthenticationStrategy = AuthenticationStrategy.ApimCertificate,
+                LoginId = "loginId",
+                ApimTenantId = "apimTenantId",
+                ApimScope = "apimScope",
+                ApimSubscriptionKey = "apimSubscriptionKey"
+            };
+            if (apimAuth.Equals("certKeyVault"))
+            {
+                service.AuthenticationInfo.ApimCertificateName = "apimCertificateName";
+                service.AuthenticationInfo.ApimAzureKeyVaultUri = "apimAzureKeyVaultUri";
+                service.AuthenticationInfo.ApimAzureToken = new DefaultAzureCredential();
+            }
+            else if (apimAuth.Equals("certPassedIn"))
+            {
+                service.AuthenticationInfo.ApimCertificate = new Mock<X509Certificate2>().Object;
+            }
+            else if (apimAuth.Equals("certGenerateFromString"))
+            {
+                service.AuthenticationInfo.ApimCertificateStringAndPassword = ("apimCertificateString", "apimCertificatePassword");
+                service.AuthenticationInfo.ApimAzureKeyVaultUri = "apimAzureKeyVaultUri";
+            }
+            else if (apimAuth.Equals("clientSecret"))
+            {
+                service.AuthenticationInfo.AuthenticationStrategy = AuthenticationStrategy.ApimClientSecret;
+                service.AuthenticationInfo.ApimClientSecret = "apimClientSecret";
+            }
+
+            //Act
+            var response = await service.GetAsync(relativeUrl, httpClientName);
+            if (requestMessage == null)
+            {
+                Assert.Fail("Request message is null.");
+                return;
+            }
+            requestMessage.Headers.TryGetValues("Authorization", out var authorizationHeader);
+
+            //Assert
+            Assert.Multiple(() =>
+            {
+                if (apimAuth.Equals("certKeyVault"))
+                {
+                    azureAdClientAssertion.Verify(x => x.GetCertificateFromKeyVault(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TokenCredential?>()), Times.Once);
+                    azureAdClientAssertion.Verify(x => x.GetTokenAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<X509Certificate2>(), It.IsAny<string>()), Times.Once);
+                }
+                else if (apimAuth.Equals("certPassedIn"))
+                {
+                    azureAdClientAssertion.Verify(x => x.GetTokenAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<X509Certificate2>(), It.IsAny<string>()), Times.Once);
+                }
+                else if (apimAuth.Equals("certGenerateFromString"))
+                {
+                    azureAdClientAssertion.Verify(x => x.GenerateCertificateFromString(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+                    azureAdClientAssertion.Verify(x => x.GetTokenAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<X509Certificate2>(), It.IsAny<string>()), Times.Once);
+                }
+                else if (apimAuth.Equals("clientSecret"))
+                {
+                    azureAdClientAssertion.Verify(x => x.GetTokenAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+                }
+                if (tokenReturned)
+                {
+                    Assert.That(authorizationHeader, Is.Not.Null);
+                    Assert.That(authorizationHeader?.First(), Is.EqualTo($"Bearer {token}"));
+                    if (tokenStorage.Equals("redis"))
+                    {
+                        redis?.Verify(x => x.Get(It.IsAny<string>()), Times.Once);
+                        redis?.Verify(x => x.Set(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>()), Times.Once);
+                    }
+                    else if (tokenStorage.Equals("memoryCache"))
+                    {
+                        Assert.That(memoryCache?.Get(httpClientName), Is.EqualTo(token));
+                    }
+                }
+                else
+                {
+                    Assert.That(authorizationHeader, Is.Null);
+                    if (tokenStorage.Equals("redis"))
+                    {
+                        redis?.Verify(x => x.Get(It.IsAny<string>()), Times.Once);
+                        redis?.Verify(x => x.Set(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>()), Times.Never);
+                    }
+                    else if (tokenStorage.Equals("memoryCache"))
+                    {
+                        Assert.That(memoryCache?.Get(httpClientName), Is.Null);
+                    }
+                }
+
+            });
+            if (memoryCache != null)
+            {
+                memoryCache?.Dispose();
+            }
+        }
+
+        [Test]
+        [TestCase("none", true)]
+        [TestCase("none", false)]
+        [TestCase("redis", true)]
+        [TestCase("redis", false)]
+        [TestCase("memoryCache", true)]
+        [TestCase("memoryCache", false)]
+        public async Task GetBasicToken_Verify(string tokenStorage, bool tokenReturned)
+        {
+            //Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Session = session.Object;
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            var delegatingHandler = new Mock<DelegatingHandler>();
+            var delegatingHandlerAuth = new Mock<DelegatingHandler>();
+            HttpRequestMessage? requestMessage = null;
+            HttpRequestMessage? requestMessageAuth = null;
+            delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessage = request).ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+            var tokenResponse = new BasicTokenResponse()
+            {
+                Access_Token = token,
+                Expires = 1,
+                Token_Type = "tokenType"
+            };
+            var httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(tokenResponse)
+            };
+            if (tokenReturned)
+            {
+                delegatingHandlerAuth.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessageAuth = request).ReturnsAsync(httpResponseMessage);
+            }
+            else
+            {
+                delegatingHandlerAuth.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessageAuth = request).ReturnsAsync(new HttpResponseMessage(HttpStatusCode.NotFound));
+            }
+            delegatingHandler.As<IDisposable>().Setup(x => x.Dispose());
+            delegatingHandlerAuth.As<IDisposable>().Setup(x => x.Dispose());
+            var httpClient = new HttpClient(delegatingHandler.Object);
+            var httpClientAuth = new HttpClient(delegatingHandlerAuth.Object);
+            httpClientFactory.Setup(x => x.CreateClient(httpClientName)).Returns(httpClient);
+            httpClientFactory.Setup(x => x.CreateClient(authenticationHttpClientName)).Returns(httpClientAuth);
+            RooHttpClient service = default!;
+            Mock<IRedisService>? redis = null;
+            MemoryCache? memoryCache = null;
+            if (tokenStorage.Equals("none"))
+            {
+                service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object);
+            }
+            else if (tokenStorage.Equals("redis"))
+            {
+                redis = new Mock<IRedisService>();
+                redis.Setup(x => x.Get(It.IsAny<string>())).ReturnsAsync((string?)null);
+                redis.Setup(x => x.Set(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan>())).ReturnsAsync(true);
+                service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object, redis.Object);
+            }
+            else if (tokenStorage.Equals("memoryCache"))
+            {
+                memoryCache = new MemoryCache(new MemoryCacheOptions());
+                service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object, memoryCache);
+            }
+            service.AuthenticationInfo = new()
+            {
+                AuthenticationStrategy = AuthenticationStrategy.Basic,
+                AuthenticationHttpClientName = authenticationHttpClientName,
+                BasicEncodedContent = headers,
+                TokenUrl = "http://unittest.com/test/auth",
+                AuthenticationHeaders = headers
+            };
+
+            //Act
+            var response = await service.GetAsync(relativeUrl, httpClientName);
+            if (requestMessage == null || requestMessageAuth == null)
+            {
+                Assert.Fail("Request message is null.");
+                return;
+            }
+            requestMessage.Headers.TryGetValues("Authorization", out var authorizationHeader);
+            IEnumerable<string>? contentTypeHeader = null;
+            requestMessageAuth.Content?.Headers.TryGetValues("Content-Type", out contentTypeHeader);
+            var requestAuthContent = await requestMessageAuth.Content.ReadAsFormDataAsync();
+
+            //Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(contentTypeHeader, Is.Not.Null);
+                Assert.That(contentTypeHeader?.First(), Is.EqualTo("application/x-www-form-urlencoded"));
+                Assert.That(requestAuthContent, Is.Not.Null);
+                Assert.That(requestAuthContent[headers[0].Name], Is.Not.Null);
+                Assert.That(requestAuthContent[headers[0].Name], Is.EqualTo(headers[0].Value));
+                Assert.That(requestAuthContent[headers[1].Name], Is.Not.Null);
+                Assert.That(requestAuthContent[headers[1].Name], Is.EqualTo(headers[1].Value));
+                if (tokenReturned)
+                {
+                    Assert.That(authorizationHeader, Is.Not.Null);
+                    Assert.That(authorizationHeader?.First(), Is.EqualTo($"Bearer {token}"));
+                    if (tokenStorage.Equals("redis"))
+                    {
+                        redis?.Verify(x => x.Get(It.IsAny<string>()), Times.Once);
+                        redis?.Verify(x => x.Set(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>()), Times.Once);
+                    }
+                    else if (tokenStorage.Equals("memoryCache"))
+                    {
+                        Assert.That(memoryCache?.Get(httpClientName), Is.EqualTo(token));
+                    }
+                }
+                else
+                {
+                    Assert.That(authorizationHeader, Is.Null);
+                    if (tokenStorage.Equals("redis"))
+                    {
+                        redis?.Verify(x => x.Get(It.IsAny<string>()), Times.Once);
+                        redis?.Verify(x => x.Set(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>()), Times.Never);
+                    }
+                    else if (tokenStorage.Equals("memoryCache"))
+                    {
+                        Assert.That(memoryCache?.Get(httpClientName), Is.Null);
+                    }
+                }
+
+            });
+            if (memoryCache != null)
+            {
+                memoryCache?.Dispose();
+            }
+        }
+
+        [Test]
+        public async Task GetPassedInToken_Verify()
+        {
+            //Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Session = session.Object;
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            var delegatingHandler = new Mock<DelegatingHandler>();
+            var delegatingHandlerAuth = new Mock<DelegatingHandler>();
+            HttpRequestMessage? requestMessage = null;
+            delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessage = request).ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+            delegatingHandler.As<IDisposable>().Setup(x => x.Dispose());
+            var httpClient = new HttpClient(delegatingHandler.Object);
+            httpClientFactory.Setup(x => x.CreateClient(httpClientName)).Returns(httpClient);
+            var service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object);
+            service.AuthenticationInfo = new()
+            {
+                AuthenticationStrategy = AuthenticationStrategy.PassInToken,
+                Token = token
+            };
+
+            //Act
+            var response = await service.GetAsync(relativeUrl, httpClientName);
+            if (requestMessage == null)
+            {
+                Assert.Fail("Request message is null.");
+                return;
+            }
+            requestMessage.Headers.TryGetValues("Authorization", out var authorizationHeader);
+
+            //Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(authorizationHeader, Is.Not.Null);
+                Assert.That(authorizationHeader?.First(), Is.EqualTo($"Bearer {token}"));
+            });
+        }
+
+        [Test]
+        [TestCase("redis")]
+        [TestCase("memoryCache")]
+        public async Task GetTokenExisting_Verify(string tokenStorage)
+        {
+            //Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Session = session.Object;
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            var delegatingHandler = new Mock<DelegatingHandler>();
+            var delegatingHandlerAuth = new Mock<DelegatingHandler>();
+            HttpRequestMessage? requestMessage = null;
+            delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessage = request).ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+            delegatingHandler.As<IDisposable>().Setup(x => x.Dispose());
+            var httpClient = new HttpClient(delegatingHandler.Object);
+            httpClientFactory.Setup(x => x.CreateClient(httpClientName)).Returns(httpClient);
+            RooHttpClient service = default!;
+            Mock<IRedisService>? redis = null;
+            MemoryCache? memoryCache = null;
+            if (tokenStorage.Equals("redis"))
+            {
+                redis = new Mock<IRedisService>();
+                redis.Setup(x => x.Get(It.IsAny<string>())).ReturnsAsync(token);
+                service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object, redis.Object);
+            }
+            else if (tokenStorage.Equals("memoryCache"))
+            {
+                memoryCache = new MemoryCache(new MemoryCacheOptions());
+                memoryCache.Set(httpClientName, token);
+                service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object, memoryCache);
+            }
+            service.AuthenticationInfo = new()
+            {
+                AuthenticationStrategy = AuthenticationStrategy.PassInToken,
+                Token = "token2"
+            };
+
+            //Act
+            var response = await service.GetAsync(relativeUrl, httpClientName);
+            if (requestMessage == null)
+            {
+                Assert.Fail("Request message is null.");
+                return;
+            }
+            requestMessage.Headers.TryGetValues("Authorization", out var authorizationHeader);
+
+            //Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(authorizationHeader, Is.Not.Null);
+                Assert.That(authorizationHeader?.First(), Is.EqualTo($"Bearer {token}"));
+                if (tokenStorage.Equals("redis"))
+                {
+                    redis?.Verify(x => x.Get(It.IsAny<string>()), Times.Once);
+                }
+                else if (tokenStorage.Equals("memoryCache"))
+                {
+                    Assert.That(memoryCache?.Get(httpClientName), Is.EqualTo(token));
+                }
+            });
+            if (memoryCache != null)
+            {
+                memoryCache?.Dispose();
+            }
+        }
+
+        [Test]
+        [TestCase("redis")]
+        [TestCase("memoryCache")]
+        public async Task ClearToken_Verify(string tokenStorage)
+        {
+            //Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Session = session.Object;
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            var delegatingHandler = new Mock<DelegatingHandler>();
+            var delegatingHandlerAuth = new Mock<DelegatingHandler>();
+            HttpRequestMessage? requestMessage = null;
+            delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).Callback<HttpRequestMessage, CancellationToken>((request, cancellationToken) => requestMessage = request).ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+            delegatingHandler.As<IDisposable>().Setup(x => x.Dispose());
+            var httpClient = new HttpClient(delegatingHandler.Object);
+            httpClientFactory.Setup(x => x.CreateClient(httpClientName)).Returns(httpClient);
+            RooHttpClient service = default!;
+            Mock<IRedisService>? redis = null;
+            MemoryCache? memoryCache = null;
+            if (tokenStorage.Equals("redis"))
+            {
+                redis = new Mock<IRedisService>();
+                redis.Setup(x => x.Delete(It.IsAny<string>())).ReturnsAsync(true);
+                service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object, redis.Object);
+            }
+            else if (tokenStorage.Equals("memoryCache"))
+            {
+                memoryCache = new MemoryCache(new MemoryCacheOptions());
+                memoryCache.Set(httpClientName, token);
+                service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object, memoryCache);
+            }
+            service.AuthenticationInfo = new()
+            {
+                AuthenticationStrategy = AuthenticationStrategy.PassInToken,
+                ForceToken = true
+            };
+
+            //Act
+            var response = await service.GetAsync(relativeUrl, httpClientName);
+            if (requestMessage == null)
+            {
+                Assert.Fail("Request message is null.");
+                return;
+            }
+            requestMessage.Headers.TryGetValues("Authorization", out var authorizationHeader);
+
+            //Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(authorizationHeader, Is.Null);
+                if (tokenStorage.Equals("redis"))
+                {
+                    redis?.Verify(x => x.Delete(It.IsAny<string>()), Times.Once);
+                    redis?.Verify(x => x.Get(It.IsAny<string>()), Times.Never);
+                }
+                else if (tokenStorage.Equals("memoryCache"))
+                {
+                    Assert.That(memoryCache?.Get(httpClientName), Is.Null);
+                }
+            });
+            if (memoryCache != null)
+            {
+                memoryCache?.Dispose();
+            }
+        }
+        #endregion
+
+        #region Deserialization
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task SystemTextJsonDeserialize_Verify(bool readAsString)
+        {
+            //Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Session = session.Object;
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            var delegatingHandler = new Mock<DelegatingHandler>();
+            var httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonConvert.SerializeObject(testObject))
+            };
+            delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).ReturnsAsync(httpResponseMessage);
+            delegatingHandler.As<IDisposable>().Setup(x => x.Dispose());
+            var httpClient = new HttpClient(delegatingHandler.Object);
+            httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object);
+            service.SerializationSettings = new()
+            {
+                JsonSerializerOptions = new()
+                {
+                    AllowTrailingCommas = true,
+                    DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+                    IgnoreReadOnlyFields = false
+                }
+            };
+            if (readAsString)
+            {
+                service.SerializationSettings.ReadAsString = true;
+            }
+
+            //Act
+            var response = await service.GetAsync<Test>(relativeUrl, httpClientName);
+            //Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(response, Is.Not.Null);
+                Assert.That(response.Id, Is.EqualTo(testObject.Id));
+                Assert.That(response.Value, Is.EqualTo(testObject.Value));
+            });
+        }
+
+        [Test]
+        [TestCase("none", true)]
+        [TestCase("none", false)]
+        [TestCase("default", true)]
+        [TestCase("default", false)]
+        [TestCase("custom", true)]
+        [TestCase("custom", false)]
+        public async Task NewtonsoftJsonDeserialize_Verify(string settingsToUse, bool readAsString)
+        {
+            //Arrange
+            var httpContext = new DefaultHttpContext();
+            httpContext.Session = session.Object;
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            var delegatingHandler = new Mock<DelegatingHandler>();
+            var httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonConvert.SerializeObject(testObject))
+            };
+            delegatingHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).ReturnsAsync(httpResponseMessage);
+            delegatingHandler.As<IDisposable>().Setup(x => x.Dispose());
+            var httpClient = new HttpClient(delegatingHandler.Object);
+            httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var service = new RooHttpClient(channelId, httpContextAccessor.Object, httpClientFactory.Object, loggerMoq.Object, azureAdClientAssertionMoq.Object);
+            service.SerializationSettings = new();
+            if (settingsToUse.Equals("default"))
+            {
+                service.SerializationSettings.UseDefaultSerializationSettings = true;
+            }
+            else if(settingsToUse.Equals("custom"))
+            {
+                service.SerializationSettings.JsonSerializerSettings = new()
+                {
+                    Culture = CultureInfo.CurrentCulture,
+                    NullValueHandling = NullValueHandling.Include,
+                    DefaultValueHandling = DefaultValueHandling.Include
+                };
+            }
+            if (readAsString)
+            {
+                service.SerializationSettings.ReadAsString = true;
+            }
+
+            //Act
+            var response = await service.GetAsync<Test>(relativeUrl, httpClientName);
+            //Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(response, Is.Not.Null);
+                Assert.That(response.Id, Is.EqualTo(testObject.Id));
+                Assert.That(response.Value, Is.EqualTo(testObject.Value));
+            });
+        }
+        #endregion
+
+        public class Test
+        {
+            public int Id { get; set; }
+            public string? Value { get; set; } = null;
+        }
+
+        public enum TestClientName
+        {
+            httpClientName = 0
+        }
+    }
+}

--- a/Roo.Azure.Configuration.Tests/UnitTests/RooLoggerTests.cs
+++ b/Roo.Azure.Configuration.Tests/UnitTests/RooLoggerTests.cs
@@ -8,14 +8,14 @@ namespace Roo.Azure.Configuration.Tests.UnitTests
     public class RooLoggerTests
     {
         //Common
-        Mock<ILogger<RooLogger>> loggerMoq;
-        Mock<IHeaderService> headerServiceMoq;
-        Mock<IHeaderService> headerServiceWithUserInfoMoq;
-        Mock<IHttpContextAccessor> httpContextAccessorMoq;
-        UserInfo userInfo = new() { LoginId = "loginId", UserId = "userId", Email = "email", SubId = "subId", IsAuthenticated = true };
-        DefaultHttpContext httpContext = new();
-        string message = "test";
-        Exception exception = new();
+        private Mock<ILogger<RooLogger>> loggerMoq;
+        private Mock<IHeaderService> headerServiceMoq;
+        private Mock<IHeaderService> headerServiceWithUserInfoMoq;
+        private Mock<IHttpContextAccessor> httpContextAccessorMoq;
+        private UserInfo userInfo = new() { LoginId = "loginId", UserId = "userId", Email = "email", SubId = "subId", IsAuthenticated = true };
+        private DefaultHttpContext httpContext = new();
+        private string message = "test";
+        private Exception exception = new();
 
         [SetUp]
         public void Setup()

--- a/Roo.Azure.Configuration.Tests/UnitTests/RooTelemetryLoggerTests.cs
+++ b/Roo.Azure.Configuration.Tests/UnitTests/RooTelemetryLoggerTests.cs
@@ -8,10 +8,10 @@ namespace Roo.Azure.Configuration.Tests.UnitTests
     public class RooTelemetryLoggerTests
     {
         //Common
-        string name = "name";
-        Dictionary<string, string> properties = new() { { "keyProperties", "valueProperties" } };
-        Dictionary<string, double> metrics = new() { { "keyMetrics", 1 } };
-        TelemetryData data = new()
+        private string name = "name";
+        private Dictionary<string, string> properties = new() { { "keyProperties", "valueProperties" } };
+        private Dictionary<string, double> metrics = new() { { "keyMetrics", 1 } };
+        private TelemetryData data = new()
         {
             User = new()
             {
@@ -54,9 +54,6 @@ namespace Roo.Azure.Configuration.Tests.UnitTests
                 Ip = "ip"
             }
         };
-
-        [SetUp]
-        public void Setup() { }
 
         [Test]
         public void TelemetryDataRemains_VerifyLog()

--- a/Roo.Azure.Configuration.Tests/UnitTests/ServiceBusServiceTests.cs
+++ b/Roo.Azure.Configuration.Tests/UnitTests/ServiceBusServiceTests.cs
@@ -7,19 +7,16 @@ namespace Roo.Azure.Configuration.Tests.UnitTests
     public class ServiceBusServiceTests
     {
         //Common
-        string serviceBusNamespace = "serviceBusNamespace";
-        string serviceBusQueueName = "serviceBusQueueName";
-        string serviceBusConnectionString = "serviceBusConnectionString";
-        string messageString = "message";
-        ReadOnlyMemory<byte> messageReadOnlyMemory = new ReadOnlyMemory<byte>([0]);
-        BinaryData binaryData = new BinaryData([0]);
-        ServiceBusMessage serviceBusMessage = new ServiceBusMessage("message");
-        DefaultAzureCredential token = new();
-        DateTimeOffset dateTimeOffset = new();
-        CancellationToken cancellationToken = new();
-
-        [SetUp]
-        public void Setup() { }
+        private string serviceBusNamespace = "serviceBusNamespace";
+        private string serviceBusQueueName = "serviceBusQueueName";
+        private string serviceBusConnectionString = "serviceBusConnectionString";
+        private string messageString = "message";
+        private ReadOnlyMemory<byte> messageReadOnlyMemory = new ReadOnlyMemory<byte>([0]);
+        private BinaryData binaryData = new BinaryData([0]);
+        private ServiceBusMessage serviceBusMessage = new ServiceBusMessage("message");
+        private DefaultAzureCredential token = new();
+        private DateTimeOffset dateTimeOffset = new();
+        private CancellationToken cancellationToken = new();
 
         #region String
         [Test]

--- a/Roo.Azure.Configuration.Tests/UnitTests/ServiceExceptionConverterTests.cs
+++ b/Roo.Azure.Configuration.Tests/UnitTests/ServiceExceptionConverterTests.cs
@@ -6,10 +6,7 @@ namespace Roo.Azure.Configuration.Tests.UnitTests
     public class ServiceExceptionConverterTests
     {
         //Common
-        string transactionId = "transactionId";
-
-        [SetUp]
-        public void Setup() { }
+        private string transactionId = "transactionId";
 
         [Test]
         public void ConvertToServiceException_Verify()

--- a/Roo.Azure.Configuration.Tests/UnitTests/ServiceExceptionFilterTests.cs
+++ b/Roo.Azure.Configuration.Tests/UnitTests/ServiceExceptionFilterTests.cs
@@ -9,10 +9,7 @@ namespace Roo.Azure.Configuration.Tests.UnitTests
     public class ServiceExceptionFilterTests
     {
         //Common
-        string transactionId = "transactionId";
-
-        [SetUp]
-        public void Setup() { }
+        private string transactionId = "transactionId";
 
         [Test]
         public async Task ExceptionFilter_Verify()

--- a/Roo.Azure.Configuration.Tests/UnitTests/ServiceExceptionMiddlewareTests.cs
+++ b/Roo.Azure.Configuration.Tests/UnitTests/ServiceExceptionMiddlewareTests.cs
@@ -8,8 +8,8 @@ namespace Roo.Azure.Configuration.Tests.UnitTests
     public class ServiceExceptionMiddlewareTests
     {
         //Common
-        Mock<IRooLogger> loggerMoq;
-        Mock<IWebHostEnvironment> webHostEnvironment;
+        private Mock<IRooLogger> loggerMoq;
+        private Mock<IWebHostEnvironment> webHostEnvironment;
 
         [SetUp]
         public void Setup()

--- a/Roo.Azure.Configuration.Tests/UnitTests/SwaggerFilterTests.cs
+++ b/Roo.Azure.Configuration.Tests/UnitTests/SwaggerFilterTests.cs
@@ -8,11 +8,8 @@ namespace Roo.Azure.Configuration.Tests.UnitTests
     public class SwaggerFilterTests
     {
         //Common
-        string controller = "TestController";
-        string schema = "TestModel";
-
-        [SetUp]
-        public void Setup() { }
+        private string controller = "TestController";
+        private string schema = "TestModel";
 
         [Test]
         public void ApplyPathsFilter_Verify()

--- a/Roo.Azure.Configuration.Tests/UnitTests/SwaggerHeaderTests.cs
+++ b/Roo.Azure.Configuration.Tests/UnitTests/SwaggerHeaderTests.cs
@@ -11,11 +11,8 @@ namespace Roo.Azure.Configuration.Tests.UnitTests
     public class SwaggerHeaderTests
     {
         //Common
-        string sessionId = "sessionId";
-        string channelId = "channelId";
-
-        [SetUp]
-        public void Setup() { }
+        private string sessionId = "sessionId";
+        private string channelId = "channelId";
 
         [Test]
         public void ApplyHeadersToSwagger_Verify()

--- a/Roo.Azure.Configuration.Tests/UnitTests/TelemetryInitializerTests.cs
+++ b/Roo.Azure.Configuration.Tests/UnitTests/TelemetryInitializerTests.cs
@@ -3,8 +3,6 @@ using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json;
-using Roo.Azure.Configuration.Common.Logging;
-using Roo.Azure.Configuration.Common.Middlewares;
 using Roo.Azure.Configuration.Common.Models;
 using Roo.Azure.Configuration.Common.Telemetry;
 using System.Security.Claims;
@@ -14,15 +12,10 @@ namespace Roo.Azure.Configuration.Tests.UnitTests
     public class TelemetryInitializerTests
     {
         //Common
-        string sessionId = "sessionId";
-        string transactionId = "transactionId";
-        string channelId = "channelId";
-        string loginId = "loginId";
-
-        [SetUp]
-        public void Setup()
-        {
-        }
+        private string sessionId = "sessionId";
+        private string transactionId = "transactionId";
+        private string channelId = "channelId";
+        private string loginId = "loginId";
 
         [Test]
         public void InitializeCloudRoleNameTelemetry_Verify()


### PR DESCRIPTION
add cancellation token to all Http methods
make memory cache optional in AzureAd if Redis or MemoryCache are already being used in RooHttpClient

#27 close